### PR TITLE
make IO hidden in static effect checked at compile time

### DIFF
--- a/effectful-core/effectful-core.cabal
+++ b/effectful-core/effectful-core.cabal
@@ -51,6 +51,7 @@ common language
                         TypeApplications
                         TypeFamilies
                         TypeOperators
+                        StandaloneKindSignatures
 
 library effectful-internal-utils
     import:          language

--- a/effectful-core/src/Effectful/Dispatch/Static.hs
+++ b/effectful-core/src/Effectful/Dispatch/Static.hs
@@ -56,6 +56,8 @@ module Effectful.Dispatch.Static
   , putEnv
   , stateEnv
   , modifyEnv
+  , NeedsIO
+  , deferIO
   ) where
 
 import Effectful.Internal.Env

--- a/effectful-core/src/Effectful/Dispatch/Static.hs
+++ b/effectful-core/src/Effectful/Dispatch/Static.hs
@@ -58,6 +58,7 @@ module Effectful.Dispatch.Static
   , modifyEnv
   , NeedsIO
   , deferIO
+  , deferIO_
   ) where
 
 import Effectful.Internal.Env

--- a/effectful-core/src/Effectful/Reader/Static.hs
+++ b/effectful-core/src/Effectful/Reader/Static.hs
@@ -21,6 +21,7 @@ data Reader r :: Effect
 
 type instance DispatchOf (Reader r) = 'Static
 newtype instance StaticRep (Reader r) = Reader r
+type instance NeedsIO (Reader r) = 'False
 
 -- | Run a 'Reader' effect with the given initial environment.
 runReader

--- a/effectful-core/src/Effectful/State/Static/Local.hs
+++ b/effectful-core/src/Effectful/State/Static/Local.hs
@@ -49,6 +49,7 @@ data State s :: Effect
 
 type instance DispatchOf (State s) = 'Static
 newtype instance StaticRep (State s) = State s
+type instance NeedsIO (State s) = 'False
 
 -- | Run the 'State' effect with the given initial state and return the final
 -- value along with the final state.

--- a/effectful-core/src/Effectful/State/Static/Shared.hs
+++ b/effectful-core/src/Effectful/State/Static/Shared.hs
@@ -51,6 +51,7 @@ data State s :: Effect
 
 type instance DispatchOf (State s) = 'Static
 newtype instance StaticRep (State s) = State (MVar s)
+type instance NeedsIO (State s) = 'False
 
 -- | Run the 'State' effect with the given initial state and return the final
 -- value along with the final state.

--- a/effectful-core/src/Effectful/Writer/Static/Local.hs
+++ b/effectful-core/src/Effectful/Writer/Static/Local.hs
@@ -38,6 +38,7 @@ data Writer w :: Effect
 
 type instance DispatchOf (Writer w) = 'Static
 newtype instance StaticRep (Writer w) = Writer w
+type instance NeedsIO (Writer w) = 'False
 
 -- | Run a 'Writer' effect and return the final value along with the final
 -- output.

--- a/effectful-core/src/Effectful/Writer/Static/Shared.hs
+++ b/effectful-core/src/Effectful/Writer/Static/Shared.hs
@@ -38,6 +38,7 @@ data Writer w :: Effect
 
 type instance DispatchOf (Writer w) = 'Static
 newtype instance StaticRep (Writer w) = Writer (MVar w)
+type instance NeedsIO (Writer w) = 'False
 
 -- | Run a 'Writer' effect and return the final value along with the final
 -- output.

--- a/effectful/src/Effectful/Concurrent/Effect.hs
+++ b/effectful/src/Effectful/Concurrent/Effect.hs
@@ -73,6 +73,7 @@ data Concurrent :: Effect
 
 type instance DispatchOf Concurrent = 'Static
 data instance StaticRep Concurrent = Concurrent
+type instance NeedsIO Concurrent = 'True
 
 -- | Run the 'Concurrent' effect.
 runConcurrent :: IOE :> es => Eff (Concurrent : es) a -> Eff es a

--- a/effectful/src/Effectful/Environment.hs
+++ b/effectful/src/Effectful/Environment.hs
@@ -21,12 +21,14 @@ import qualified System.Environment as E
 
 import Effectful
 import Effectful.Dispatch.Static hiding (getEnv)
+import Data.Proxy (Proxy(Proxy))
 
 -- | An effect for querying and modifying the system environment.
 data Environment :: Effect
 
 type instance DispatchOf Environment = 'Static
 data instance StaticRep Environment = Environment
+type instance NeedsIO Environment = 'True
 
 -- | Run the 'Environment' effect.
 runEnvironment :: IOE :> es => Eff (Environment : es) a -> Eff es a
@@ -34,35 +36,35 @@ runEnvironment = evalStaticRep Environment
 
 -- | Lifted 'E.getArgs'.
 getArgs :: Environment :> es => Eff es [String]
-getArgs = unsafeEff_ E.getArgs
+getArgs = deferIO_ (Proxy @Environment) E.getArgs
 
 -- | Lifted 'E.getEnv'.
 getEnv :: Environment :> es => String -> Eff es String
-getEnv = unsafeEff_ . E.getEnv
+getEnv = deferIO_ (Proxy @Environment) . E.getEnv
 
 -- | Lifted 'E.getEnvironment'.
 getEnvironment :: Environment :> es => Eff es [(String, String)]
-getEnvironment = unsafeEff_ E.getEnvironment
+getEnvironment = deferIO_ (Proxy @Environment) E.getEnvironment
 
 -- | Lifted 'E.getExecutablePath'.
 getExecutablePath :: Environment :> es => Eff es FilePath
-getExecutablePath = unsafeEff_ E.getExecutablePath
+getExecutablePath = deferIO_ (Proxy @Environment) E.getExecutablePath
 
 -- | Lifted 'E.getProgName'.
 getProgName :: Environment :> es => Eff es String
-getProgName = unsafeEff_ E.getProgName
+getProgName = deferIO_ (Proxy @Environment) E.getProgName
 
 -- | Lifted 'E.lookupEnv'.
 lookupEnv :: Environment :> es => String -> Eff es (Maybe String)
-lookupEnv = unsafeEff_ . E.lookupEnv
+lookupEnv = deferIO_ (Proxy @Environment) . E.lookupEnv
 
 -- | Lifted 'E.setEnv'.
 setEnv :: Environment :> es => String -> String -> Eff es ()
-setEnv n = unsafeEff_ . E.setEnv n
+setEnv n = deferIO_ (Proxy @Environment) . E.setEnv n
 
 -- | Lifted 'E.unsetEnv'.
 unsetEnv :: Environment :> es => String -> Eff es ()
-unsetEnv = unsafeEff_ . E.unsetEnv
+unsetEnv = deferIO_ (Proxy @Environment) . E.unsetEnv
 
 -- | Lifted 'E.withArgs'.
 withArgs :: Environment :> es => [String] -> Eff es a -> Eff es a

--- a/effectful/src/Effectful/FileSystem/Effect.hs
+++ b/effectful/src/Effectful/FileSystem/Effect.hs
@@ -11,6 +11,7 @@ data FileSystem :: Effect
 
 type instance DispatchOf FileSystem = 'Static
 data instance StaticRep FileSystem = FileSystem
+type instance NeedsIO FileSystem = 'True
 
 -- | Run the 'FileSystem' effect.
 runFileSystem :: IOE :> es => Eff (FileSystem : es) a -> Eff es a

--- a/effectful/src/Effectful/FileSystem/IO.hs
+++ b/effectful/src/Effectful/FileSystem/IO.hs
@@ -64,80 +64,80 @@ withBinaryFile fp mode inner = unsafeUnliftIO $ \unlift -> do
 
 -- | Lifted version of 'IO.openFile'
 openFile :: FileSystem :> es => FilePath -> IOMode -> Eff es Handle
-openFile fp = unsafeEff_ . IO.openFile fp
+openFile fp = deferIO . IO.openFile fp
 
 -- | Lifted version of 'IO.hClose'
 hClose :: FileSystem :> es => Handle -> Eff es ()
-hClose = unsafeEff_ . IO.hClose
+hClose = deferIO . IO.hClose
 
 -- | Lifted version of 'IO.hFlush'
 hFlush :: FileSystem :> es => Handle -> Eff es ()
-hFlush = unsafeEff_ . IO.hFlush
+hFlush = deferIO . IO.hFlush
 
 -- | Lifted version of 'IO.hFileSize'
 hFileSize :: FileSystem :> es => Handle -> Eff es Integer
-hFileSize = unsafeEff_ . IO.hFileSize
+hFileSize = deferIO . IO.hFileSize
 
 -- | Lifted version of 'IO.hSetFileSize'
 hSetFileSize :: FileSystem :> es => Handle -> Integer -> Eff es ()
-hSetFileSize h = unsafeEff_ . IO.hSetFileSize h
+hSetFileSize h = deferIO . IO.hSetFileSize h
 
 -- | Lifted version of 'IO.hIsEOF'
 hIsEOF :: FileSystem :> es => Handle -> Eff es Bool
-hIsEOF = unsafeEff_ . IO.hIsEOF
+hIsEOF = deferIO . IO.hIsEOF
 
 -- | Lifted version of 'IO.hSetBuffering'
 hSetBuffering :: FileSystem :> es => Handle -> IO.BufferMode -> Eff es ()
-hSetBuffering h = unsafeEff_ . IO.hSetBuffering h
+hSetBuffering h = deferIO . IO.hSetBuffering h
 
 -- | Lifted version of 'IO.hGetBuffering'
 hGetBuffering :: FileSystem :> es => Handle -> Eff es IO.BufferMode
-hGetBuffering = unsafeEff_ . IO.hGetBuffering
+hGetBuffering = deferIO . IO.hGetBuffering
 
 -- | Lifted version of 'IO.hSeek'
 hSeek :: FileSystem :> es => Handle -> IO.SeekMode -> Integer -> Eff es ()
-hSeek h s = unsafeEff_ . IO.hSeek h s
+hSeek h s = deferIO . IO.hSeek h s
 
 -- | Lifted version of 'IO.hTell'
 hTell :: FileSystem :> es => Handle -> Eff es Integer
-hTell = unsafeEff_ . IO.hTell
+hTell = deferIO . IO.hTell
 
 -- | Lifted version of 'IO.hIsOpen'
 hIsOpen :: FileSystem :> es => Handle -> Eff es Bool
-hIsOpen = unsafeEff_ . IO.hIsOpen
+hIsOpen = deferIO . IO.hIsOpen
 
 -- | Lifted version of 'IO.hIsClosed'
 hIsClosed :: FileSystem :> es => Handle -> Eff es Bool
-hIsClosed = unsafeEff_ . IO.hIsClosed
+hIsClosed = deferIO . IO.hIsClosed
 
 -- | Lifted version of 'IO.hIsReadable'
 hIsReadable :: FileSystem :> es => Handle -> Eff es Bool
-hIsReadable = unsafeEff_ . IO.hIsReadable
+hIsReadable = deferIO . IO.hIsReadable
 
 -- | Lifted version of 'IO.hIsWritable'
 hIsWritable :: FileSystem :> es => Handle -> Eff es Bool
-hIsWritable = unsafeEff_ . IO.hIsWritable
+hIsWritable = deferIO . IO.hIsWritable
 
 -- | Lifted version of 'IO.hIsSeekable'
 hIsSeekable :: FileSystem :> es => Handle -> Eff es Bool
-hIsSeekable = unsafeEff_ . IO.hIsSeekable
+hIsSeekable = deferIO . IO.hIsSeekable
 
 -- | Lifted version of 'IO.hIsTerminalDevice'
 hIsTerminalDevice :: FileSystem :> es => Handle -> Eff es Bool
-hIsTerminalDevice = unsafeEff_ . IO.hIsTerminalDevice
+hIsTerminalDevice = deferIO . IO.hIsTerminalDevice
 
 -- | Lifted version of 'IO.hSetEcho'
 hSetEcho :: FileSystem :> es => Handle -> Bool -> Eff es ()
-hSetEcho h = unsafeEff_ . IO.hSetEcho h
+hSetEcho h = deferIO . IO.hSetEcho h
 
 -- | Lifted version of 'IO.hGetEcho'
 hGetEcho :: FileSystem :> es => Handle -> Eff es Bool
-hGetEcho = unsafeEff_ . IO.hGetEcho
+hGetEcho = deferIO . IO.hGetEcho
 
 -- | Lifted version of 'IO.hWaitForInput'
 hWaitForInput :: FileSystem :> es => Handle -> Int -> Eff es Bool
-hWaitForInput h = unsafeEff_ . IO.hWaitForInput h
+hWaitForInput h = deferIO . IO.hWaitForInput h
 
 -- | Lifted version of 'IO.hReady'
 hReady :: FileSystem :> es => Handle -> Eff es Bool
-hReady = unsafeEff_ . IO.hReady
+hReady = deferIO . IO.hReady

--- a/effectful/src/Effectful/FileSystem/IO.hs
+++ b/effectful/src/Effectful/FileSystem/IO.hs
@@ -37,10 +37,10 @@ module Effectful.FileSystem.IO
 
 import qualified System.IO as IO
 import System.IO (Handle, IOMode (..))
-
 import Effectful
 import Effectful.Dispatch.Static
 import Effectful.FileSystem.Effect
+import Data.Proxy (Proxy(Proxy))
 
 -- | Lifted version of 'IO.withFile'.
 withFile
@@ -64,80 +64,80 @@ withBinaryFile fp mode inner = unsafeUnliftIO $ \unlift -> do
 
 -- | Lifted version of 'IO.openFile'
 openFile :: FileSystem :> es => FilePath -> IOMode -> Eff es Handle
-openFile fp = deferIO . IO.openFile fp
+openFile fp = deferIO_ (Proxy @FileSystem) . IO.openFile fp
 
 -- | Lifted version of 'IO.hClose'
 hClose :: FileSystem :> es => Handle -> Eff es ()
-hClose = deferIO . IO.hClose
+hClose = deferIO_ (Proxy @FileSystem) . IO.hClose
 
 -- | Lifted version of 'IO.hFlush'
 hFlush :: FileSystem :> es => Handle -> Eff es ()
-hFlush = deferIO . IO.hFlush
+hFlush = deferIO_ (Proxy @FileSystem) . IO.hFlush
 
 -- | Lifted version of 'IO.hFileSize'
 hFileSize :: FileSystem :> es => Handle -> Eff es Integer
-hFileSize = deferIO . IO.hFileSize
+hFileSize = deferIO_ (Proxy @FileSystem) . IO.hFileSize
 
 -- | Lifted version of 'IO.hSetFileSize'
 hSetFileSize :: FileSystem :> es => Handle -> Integer -> Eff es ()
-hSetFileSize h = deferIO . IO.hSetFileSize h
+hSetFileSize h = deferIO_ (Proxy @FileSystem) . IO.hSetFileSize h
 
 -- | Lifted version of 'IO.hIsEOF'
 hIsEOF :: FileSystem :> es => Handle -> Eff es Bool
-hIsEOF = deferIO . IO.hIsEOF
+hIsEOF = deferIO_ (Proxy @FileSystem) . IO.hIsEOF
 
 -- | Lifted version of 'IO.hSetBuffering'
 hSetBuffering :: FileSystem :> es => Handle -> IO.BufferMode -> Eff es ()
-hSetBuffering h = deferIO . IO.hSetBuffering h
+hSetBuffering h = deferIO_ (Proxy @FileSystem) . IO.hSetBuffering h
 
 -- | Lifted version of 'IO.hGetBuffering'
 hGetBuffering :: FileSystem :> es => Handle -> Eff es IO.BufferMode
-hGetBuffering = deferIO . IO.hGetBuffering
+hGetBuffering = deferIO_ (Proxy @FileSystem) . IO.hGetBuffering
 
 -- | Lifted version of 'IO.hSeek'
 hSeek :: FileSystem :> es => Handle -> IO.SeekMode -> Integer -> Eff es ()
-hSeek h s = deferIO . IO.hSeek h s
+hSeek h s = deferIO_ (Proxy @FileSystem) . IO.hSeek h s
 
 -- | Lifted version of 'IO.hTell'
 hTell :: FileSystem :> es => Handle -> Eff es Integer
-hTell = deferIO . IO.hTell
+hTell = deferIO_ (Proxy @FileSystem) . IO.hTell
 
 -- | Lifted version of 'IO.hIsOpen'
 hIsOpen :: FileSystem :> es => Handle -> Eff es Bool
-hIsOpen = deferIO . IO.hIsOpen
+hIsOpen = deferIO_ (Proxy @FileSystem) . IO.hIsOpen
 
 -- | Lifted version of 'IO.hIsClosed'
 hIsClosed :: FileSystem :> es => Handle -> Eff es Bool
-hIsClosed = deferIO . IO.hIsClosed
+hIsClosed = deferIO_ (Proxy @FileSystem) . IO.hIsClosed
 
 -- | Lifted version of 'IO.hIsReadable'
 hIsReadable :: FileSystem :> es => Handle -> Eff es Bool
-hIsReadable = deferIO . IO.hIsReadable
+hIsReadable = deferIO_ (Proxy @FileSystem) . IO.hIsReadable
 
 -- | Lifted version of 'IO.hIsWritable'
 hIsWritable :: FileSystem :> es => Handle -> Eff es Bool
-hIsWritable = deferIO . IO.hIsWritable
+hIsWritable = deferIO_ (Proxy @FileSystem) . IO.hIsWritable
 
 -- | Lifted version of 'IO.hIsSeekable'
 hIsSeekable :: FileSystem :> es => Handle -> Eff es Bool
-hIsSeekable = deferIO . IO.hIsSeekable
+hIsSeekable = deferIO_ (Proxy @FileSystem) . IO.hIsSeekable
 
 -- | Lifted version of 'IO.hIsTerminalDevice'
 hIsTerminalDevice :: FileSystem :> es => Handle -> Eff es Bool
-hIsTerminalDevice = deferIO . IO.hIsTerminalDevice
+hIsTerminalDevice = deferIO_ (Proxy @FileSystem) . IO.hIsTerminalDevice
 
 -- | Lifted version of 'IO.hSetEcho'
 hSetEcho :: FileSystem :> es => Handle -> Bool -> Eff es ()
-hSetEcho h = deferIO . IO.hSetEcho h
+hSetEcho h = deferIO_ (Proxy @FileSystem) . IO.hSetEcho h
 
 -- | Lifted version of 'IO.hGetEcho'
 hGetEcho :: FileSystem :> es => Handle -> Eff es Bool
-hGetEcho = deferIO . IO.hGetEcho
+hGetEcho = deferIO_ (Proxy @FileSystem) . IO.hGetEcho
 
 -- | Lifted version of 'IO.hWaitForInput'
 hWaitForInput :: FileSystem :> es => Handle -> Int -> Eff es Bool
-hWaitForInput h = deferIO . IO.hWaitForInput h
+hWaitForInput h = deferIO_ (Proxy @FileSystem) . IO.hWaitForInput h
 
 -- | Lifted version of 'IO.hReady'
 hReady :: FileSystem :> es => Handle -> Eff es Bool
-hReady = deferIO . IO.hReady
+hReady = deferIO_ (Proxy @FileSystem) . IO.hReady

--- a/effectful/src/Effectful/Process.hs
+++ b/effectful/src/Effectful/Process.hs
@@ -58,6 +58,7 @@ data Process :: Effect
 
 type instance DispatchOf Process = 'Static
 data instance StaticRep Process = Process
+type instance NeedsIO Process = 'True
 
 runProcess :: IOE :> es => Eff (Process : es) a -> Eff es a
 runProcess = evalStaticRep Process

--- a/effectful/src/Effectful/Resource.hs
+++ b/effectful/src/Effectful/Resource.hs
@@ -26,12 +26,14 @@ import qualified Control.Monad.Trans.Resource.Internal as RI
 
 import Effectful
 import Effectful.Dispatch.Static
+import Effectful.Internal.Monad (unsafeEvalStaticRep)
 
 -- | Data tag for a resource effect.
 data Resource :: Effect
 
 type instance DispatchOf Resource = 'Static
 newtype instance StaticRep Resource = Resource R.InternalState
+type instance NeedsIO Resource = 'True
 
 -- | Run the resource effect.
 runResource :: IOE :> es => Eff (Resource : es) a -> Eff es a
@@ -61,7 +63,7 @@ getInternalState = do
 --
 -- /Note:/ the 'R.InternalState' will not be closed at the end.
 runInternalState :: R.InternalState -> Eff (Resource : es) a -> Eff es a
-runInternalState istate = evalStaticRep (Resource istate)
+runInternalState istate = unsafeEvalStaticRep (Resource istate)
 
 ----------------------------------------
 -- Orphan instance

--- a/effectful/src/Effectful/Temporary.hs
+++ b/effectful/src/Effectful/Temporary.hs
@@ -18,6 +18,7 @@ data Temporary :: Effect
 
 type instance DispatchOf Temporary = 'Static
 data instance StaticRep Temporary = Temporary
+type instance NeedsIO Temporary = 'True
 
 -- | Run the 'Temporary' effect.
 runTemporary :: IOE :> es => Eff (Temporary : es) a -> Eff es a

--- a/effectful/src/Effectful/Timeout.hs
+++ b/effectful/src/Effectful/Timeout.hs
@@ -14,6 +14,7 @@ data Timeout :: Effect
 
 type instance DispatchOf Timeout = 'Static
 data instance StaticRep Timeout = Timeout
+type instance NeedsIO Timeout = 'True
 
 -- | Run the 'Timeout' effect.
 runTimeout :: IOE :> es => Eff (Timeout : es) a -> Eff es a


### PR DESCRIPTION
Addresses #57 and Kleidukos/effectful-contrib#23
Makes it so that `unsafeEff_` is not needed anymore to run `IO` actions inside of a static effect. The `IOE` effect will automatically be introduced in the running function if `IO` needs to be used inside the effect