### PR TITLE
Make storage references in the environment immutable

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -1,3 +1,8 @@
+# effectful-core-2.0.0.0 (2022-??-??)
+* Make storage references in the environment immutable.
+* Remove `checkSizeEnv` and `forkEnv` from
+  `Effectful.Dispatch.Static.Primitive`.
+
 # effectful-core-1.2.0.0 (2022-07-28)
 * Change `SuffixOf` to `SharedSuffix` and make it behave as advertised.
 * Add `raiseWith`.

--- a/effectful-core/effectful-core.cabal
+++ b/effectful-core/effectful-core.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 build-type:         Simple
 name:               effectful-core
-version:            1.2.0.0
+version:            2.0.0.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Control

--- a/effectful-core/src/Effectful/Dispatch/Dynamic.hs
+++ b/effectful-core/src/Effectful/Dispatch/Dynamic.hs
@@ -353,8 +353,7 @@ interpret
   -> Eff (e : es) a
   -> Eff      es  a
 interpret handler m = unsafeEff $ \es -> do
-  les <- forkEnv es
-  (`unEff` es) $ runHandler (Handler les handler) m
+  (`unEff` es) $ runHandler (Handler es handler) m
 
 -- | Interpret an effect using other, private effects.
 --
@@ -368,9 +367,8 @@ reinterpret
   -> Eff (e : es) a
   -> Eff      es  b
 reinterpret runHandlerEs handler m = unsafeEff $ \es -> do
-  les0 <- forkEnv es
-  (`unEff` les0) . runHandlerEs . unsafeEff $ \les -> do
-    (`unEff` es) $ runHandler (Handler les handler) m
+  (`unEff` es) . runHandlerEs . unsafeEff $ \handlerEs -> do
+    (`unEff` es) $ runHandler (Handler handlerEs handler) m
 
 -- | Replace the handler of an existing effect with a new one.
 --
@@ -407,8 +405,7 @@ interpose
   -> Eff es a
   -> Eff es a
 interpose handler m = unsafeEff $ \es0 -> do
-  les <- forkEnv es0
-  bracket (replaceEnv (Handler les handler) relinkHandler es0)
+  bracket (replaceEnv (Handler es0 handler) relinkHandler es0)
           (unreplaceEnv @e)
           (\es -> unEff m es)
 
@@ -425,9 +422,8 @@ impose
   -> Eff es a
   -> Eff es b
 impose runHandlerEs handler m = unsafeEff $ \es0 -> do
-  les0 <- forkEnv es0
-  (`unEff` les0) . runHandlerEs . unsafeEff $ \les -> do
-    bracket (replaceEnv (Handler les handler) relinkHandler es0)
+  (`unEff` es0) . runHandlerEs . unsafeEff $ \handlerEs -> do
+    bracket (replaceEnv (Handler handlerEs handler) relinkHandler es0)
             (unreplaceEnv @e)
             (\es -> unEff m es)
 

--- a/effectful-core/src/Effectful/Dispatch/Static/Primitive.hs
+++ b/effectful-core/src/Effectful/Dispatch/Static/Primitive.hs
@@ -31,9 +31,7 @@ module Effectful.Dispatch.Static.Primitive
     -- ** Utils
   , emptyEnv
   , cloneEnv
-  , forkEnv
   , sizeEnv
-  , checkSizeEnv
   , tailEnv
   ) where
 

--- a/effectful-core/src/Effectful/Error/Static.hs
+++ b/effectful-core/src/Effectful/Error/Static.hs
@@ -156,7 +156,6 @@ catchError
 catchError m handler = unsafeEff $ \es -> do
   Error eid <- getEnv @(Error e) es
   catchErrorIO eid (unEff m es) $ \cs e -> do
-    checkSizeEnv es
     unEff (handler cs e) es
 
 -- | The same as @'flip' 'catchError'@, which is useful in situations where the

--- a/effectful-plugin/effectful-plugin.cabal
+++ b/effectful-plugin/effectful-plugin.cabal
@@ -59,7 +59,7 @@ library
     import:         language
 
     build-depends:    base                >= 4.13      && < 5
-                    , effectful-core      >= 1.0.0.0   && < 1.3.0.0
+                    , effectful-core      >= 1.0.0.0   && < 3.0.0.0
                     , containers          >= 0.5
                     , ghc                 >= 8.6       && < 9.3
                     , ghc-tcplugins-extra >= 0.3       && < 0.5

--- a/effectful-th/effectful-th.cabal
+++ b/effectful-th/effectful-th.cabal
@@ -56,7 +56,7 @@ library
 
     build-depends:    base                >= 4.13      && < 5
                     , containers          >= 0.6
-                    , effectful           >= 1.0.0.0   && < 1.3.0.0
+                    , effectful           >= 1.0.0.0   && < 3.0.0.0
                     , exceptions          >= 0.10.4
                     , template-haskell    >= 2.15      && < 2.20
                     , th-abstraction      >= 0.4       && < 0.5

--- a/effectful/CHANGELOG.md
+++ b/effectful/CHANGELOG.md
@@ -1,3 +1,8 @@
+# effectful-2.0.0.0 (2022-??-??)
+* Make storage references in the environment immutable.
+* Remove `checkSizeEnv` and `forkEnv` from
+  `Effectful.Dispatch.Static.Primitive`.
+
 # effectful-1.2.0.0 (2022-07-28)
 * Change `SuffixOf` to `SharedSuffix` and make it behave as advertised.
 * Add `raiseWith`.

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 build-type:         Simple
 name:               effectful
-version:            1.2.0.0
+version:            2.0.0.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Control
@@ -67,7 +67,7 @@ library
                     , async               >= 2.2.2
                     , bytestring          >= 0.10
                     , directory           >= 1.3.2
-                    , effectful-core      >= 1.2.0.0   && < 1.3.0.0
+                    , effectful-core      >= 2.0.0.0   && < 2.0.1.0
                     , process             >= 1.6.9
 
                     , time                >= 1.9.2

--- a/effectful/tests/EnvTests.hs
+++ b/effectful/tests/EnvTests.hs
@@ -4,42 +4,25 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Effectful
-import Effectful.Dispatch.Static
-import Effectful.Dispatch.Static.Primitive
 import Effectful.Reader.Static
 import Effectful.State.Static.Local
 import qualified Utils as U
 
 envTests :: TestTree
 envTests = testGroup "Env"
-  [ testCase "staircase forkEnv" test_staircaseForkEnv
-  , testCase "tailEnv through forks" test_unforkedTailEnv
+  [ testCase "tailEnv works" test_tailEnv
   , testCase "subsume works" test_subsumeEnv
   , testCase "inject works" test_injectEnv
   ]
 
-test_staircaseForkEnv :: Assertion
-test_staircaseForkEnv = runEff $ do
-  unsafeEff $ \es0 -> do
-    es0f <- forkEnv es0
-    (`unEff` es0f) $ evalState s0 $ do
-      unsafeEff $ \es1 -> do
-        es1f <- forkEnv es1
-        (`unEff` es1f) $ runReader () $ do
-          U.assertEqual "expected result" s0 =<< get
-  where
-    s0 :: Int
-    s0 = 1337
-
-test_unforkedTailEnv :: Assertion
-test_unforkedTailEnv = runEff . evalState s0 . runReader () $ do
-  unsafeEff $ \es0 -> do
-    es0f <- forkEnv es0
-    (`unEff` es0f) $ runReader () $ do
-      unsafeEff $ \es1 -> do
-        es1f <- forkEnv es1
-        (`unEff` es1f) $ runReader () . raise . raise . raise $ do
-          U.assertEqual "expected result" s0 =<< get
+test_tailEnv :: Assertion
+test_tailEnv = runEff . evalState s0 $ do
+  runReader () $ do
+    runReader () $ do
+      raise $ do
+        runReader () $ do
+          raise . raise $ do
+            U.assertEqual "expected result" s0 =<< get
   where
     s0 :: Int
     s0 = 1337


### PR DESCRIPTION
It shuffles time complexities for `Env` operations around, but overall:

- It speeds things up because of less indirections.

- It makes the API simpler since there is no longer need to fork.