### PR TITLE
Improve callstacks when using the dynamic error effect

### DIFF
--- a/effectful-core/src/Effectful/Error/Static.hs
+++ b/effectful-core/src/Effectful/Error/Static.hs
@@ -85,6 +85,7 @@ module Effectful.Error.Static
 
     -- ** Operations
   , throwError
+  , throwError'
   , catchError
   , handleError
   , tryError
@@ -141,9 +142,18 @@ throwError
   => e
   -- ^ The error.
   -> Eff es a
-throwError e = unsafeEff $ \es -> do
+throwError = throwError' callStack
+
+-- | Throw an error of type @e@, passing the CallStack argument explicitly.
+throwError'
+  :: forall e es a. Error e :> es
+  => CallStack
+  -> e
+  -- ^ The error.
+  -> Eff es a
+throwError' theCallStack e = unsafeEff $ \es -> do
   Error eid <- getEnv @(Error e) es
-  throwIO $ ErrorWrapper eid callStack (toAny e)
+  throwIO $ ErrorWrapper eid theCallStack (toAny e)
 
 -- | Handle an error of type @e@.
 catchError


### PR DESCRIPTION
When using `throwError` from `Effectful.Error.Dynamic` the call site of interest is buried under 4 lines of internal implementation details: 

```
> Left (cs,_) <- runEff $ runError @() $ throwError ()
> putStrLn $ prettyCallStack cs
CallStack (from HasCallStack):
  throwError, called at src/Effectful/Error/Dynamic.hs:43:21 in effectful-core-2.1.0.0-1rwlVbEDo1s77mEaNtxUZU:Effectful.Error.Dynamic
  handler, called at src/Effectful/Dispatch/Dynamic.hs:371:50 in effectful-core-2.1.0.0-1rwlVbEDo1s77mEaNtxUZU:Effectful.Dispatch.Dynamic
  handle, called at src/Effectful/Internal/Monad.hs:410:10 in effectful-core-2.1.0.0-1rwlVbEDo1s77mEaNtxUZU:Effectful.Internal.Monad
  send, called at src/Effectful/Error/Dynamic.hs:60:14 in effectful-core-2.1.0.0-1rwlVbEDo1s77mEaNtxUZU:Effectful.Error.Dynamic
  throwError, called at <interactive>:1:48 in interactive:Ghci1
```

We can fix this by making the `CallStack` an explicit event argument, then:
```
> Left (cs,_) <- runEff $ runError @() $ throwError ()
> putStrLn $ prettyCallStack cs
CallStack (from HasCallStack):
  throwError, called at <interactive>:12:48 in interactive:Ghci7
```
This matches the behaviour of `Effectful.Error.Static`.