### PR TITLE
Add Alternative and MonadPlus instances for Eff

### DIFF
--- a/effectful-core/src/Effectful.hs
+++ b/effectful-core/src/Effectful.hs
@@ -53,6 +53,9 @@ module Effectful
   , inject
   , Subset
 
+    -- * Exceptions
+  , AlternativeException(..)
+
     -- * Re-exports
   , MonadIO(..)
   , MonadUnliftIO(..)

--- a/effectful-core/src/Effectful/Internal/Env.hs
+++ b/effectful-core/src/Effectful/Internal/Env.hs
@@ -18,6 +18,7 @@ module Effectful.Internal.Env
     -- * Operations
   , emptyEnv
   , cloneEnv
+  , overwriteEnvWith
   , sizeEnv
   , tailEnv
 
@@ -156,6 +157,13 @@ cloneEnv (Env offset refs storage0) = do
   relinkEffects storageSize
   pure $ Env offset refs storage
 {-# NOINLINE cloneEnv #-}
+
+-- | Overwrite an environment with another one.
+overwriteEnvWith :: Env es -> Env es -> IO ()
+overwriteEnvWith es0 es = do
+  -- TODO: Update offset ? Check that those are equal ?
+  -- TODO: Update refs ? Check that those are equal ?
+  writeIORef (envStorage es0) =<< readIORef (envStorage es)
 
 -- | Get the current size of the environment.
 sizeEnv :: Env es -> IO Int

--- a/effectful-core/src/Effectful/Internal/Env.hs
+++ b/effectful-core/src/Effectful/Internal/Env.hs
@@ -161,7 +161,7 @@ cloneEnv (Env offset refs storage0) = do
 -- | Overwrite an environment with another one.
 overwriteEnvWith :: Env es -> Env es -> IO ()
 overwriteEnvWith es0 es = do
-  -- TODO: Update offset ? Check that those are equal ?
+  -- TODO: Check if offset are equal ?
   -- TODO: Update refs ? Check that those are equal ?
   writeIORef (envStorage es0) =<< readIORef (envStorage es)
 

--- a/effectful-core/src/Effectful/Internal/Monad.hs
+++ b/effectful-core/src/Effectful/Internal/Monad.hs
@@ -232,6 +232,8 @@ instance MonadFix (Eff es) where
 
 -- | __NOTE__: 'empty' will throw an 'AlternativeException' which you have to
 -- catch yourself.
+--
+-- @since: 2.2.0.0
 instance Alternative (Eff es) where
   empty = unsafeEff_ (E.throwIO EmptyAlternative)
   Eff mx <|> Eff my = unsafeEff $ \es0 -> do
@@ -246,6 +248,8 @@ instance MonadPlus (Eff es)
 
 -- | An exception that is thrown in the empty case of an alternative:
 -- > try Control.Applicative.empty  ~  Left EmptyAlternative
+--
+-- @since: 2.2.0.0
 data AlternativeException = EmptyAlternative
 
 instance C.Exception AlternativeException

--- a/effectful-core/src/Effectful/Internal/Monad.hs
+++ b/effectful-core/src/Effectful/Internal/Monad.hs
@@ -233,12 +233,12 @@ instance MonadFix (Eff es) where
 instance Alternative (Eff es) where
   empty = unsafeEff_ (E.throwIO EmptyAlternative)
   Eff mx <|> Eff my = unsafeEff $ \es0 -> do
-    let branch m = do
+    let mx' = do
           es <- cloneEnv es0
-          r <- m es
+          r <- mx es
           es0 `overwriteEnvWith` es
           pure r
-    branch mx `E.catch` (\EmptyAlternative -> branch my)
+    mx' `E.catch` (\EmptyAlternative -> my es0)
 
 instance MonadPlus (Eff es)
 

--- a/effectful-core/src/Effectful/Internal/Monad.hs
+++ b/effectful-core/src/Effectful/Internal/Monad.hs
@@ -230,6 +230,8 @@ instance MonadFix (Eff es) where
 ----------------------------------------
 -- Alternative and MonadPlus
 
+-- | __NOTE__: 'empty' will throw an 'AlternativeException' which you have to
+-- catch yourself.
 instance Alternative (Eff es) where
   empty = unsafeEff_ (E.throwIO EmptyAlternative)
   Eff mx <|> Eff my = unsafeEff $ \es0 -> do

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -132,7 +132,8 @@ test-suite test
     type:           exitcode-stdio-1.0
     main-is:        Main.hs
 
-    other-modules:  AsyncTests
+    other-modules:  AlternativeTests
+                    AsyncTests
                     ConcurrencyTests
                     EnvTests
                     EnvironmentTests

--- a/effectful/tests/AlternativeTests.hs
+++ b/effectful/tests/AlternativeTests.hs
@@ -1,0 +1,112 @@
+module AlternativeTests (alternativeTests) where
+
+import Data.Bifunctor (second)
+import Control.Applicative ((<|>), empty)
+import Control.Exception.Lifted (catch)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Effectful
+import Effectful.Dispatch.Dynamic
+import Effectful.Dispatch.Static (unsafeEff)
+import Effectful.Internal.Env (Env(..))
+import Effectful.State.Dynamic
+
+import qualified Utils as U
+
+alternativeTests :: TestTree
+alternativeTests = testGroup "Alternative"
+  [ testCase "empty" test_empty
+  , testGroup "left"
+    [ testCase "identity" test_leftIdentity
+    , testCase "interpose" test_leftInterpose
+    ]
+  , testGroup "right"
+    [ testCase "identity" test_rightIdentity
+    , testCase "interpose" test_rightInterpose
+    ]
+  ]
+
+test_empty :: Assertion
+test_empty = runEff $ do
+  r <- (empty >> pure False) `catch` (\EmptyAlternative -> pure True)
+  U.assertEqual "expected result" True r
+
+test_leftIdentity :: Assertion
+test_leftIdentity = runEff . evalStateLocal x $ do
+  mx <|> my
+  r <- get @Int
+  U.assertEqual "expected result" 1 r
+  where
+    x :: Int
+    x = 0
+
+    mx, my :: State Int :> es => Eff es ()
+    mx = put (1 :: Int)
+    my = empty
+
+test_leftInterpose :: Assertion
+test_leftInterpose = do
+  (es0, r0) <- runEff . evalStateLocal x $ do
+    es <- mx
+    r <- get @Int
+    pure (es, r)
+  (es, r) <- runEff . evalStateLocal x $ do
+    es <- mx <|> my
+    r <- get @Int
+    pure (es, r)
+  assertEqual "expected environment offset" (envOffset es0) (envOffset es)
+  assertEqual "expected environment refs" (envRefs es0) (envRefs es)
+  assertEqual "expected result" r0 r
+  where
+    x :: Int
+    x = 0
+
+    mx, my :: State Int :> es => Eff es (Env es)
+    mx = plusOne $ put (1 :: Int) >> unsafeEff pure
+    my = plusOne $ empty >> unsafeEff pure
+
+test_rightIdentity :: Assertion
+test_rightIdentity = runEff . evalStateLocal x $ do
+  mx <|> my
+  r <- get @Int
+  U.assertEqual "expected result" 2 r
+  where
+    x :: Int
+    x = 0
+
+    mx, my :: State Int :> es => Eff es ()
+    mx = empty
+    my = put (2 :: Int)
+
+test_rightInterpose :: Assertion
+test_rightInterpose = do
+  (es0, r0) <- runEff . evalStateLocal x $ do
+    es <- my
+    r <- get @Int
+    pure (es, r)
+  (es, r) <- runEff . evalStateLocal x $ do
+    es <- mx <|> my
+    r <- get @Int
+    pure (es, r)
+  assertEqual "expected environment offset" (envOffset es0) (envOffset es)
+  assertEqual "expected environment refs" (envRefs es0) (envRefs es)
+  assertEqual "expected result" r0 r
+  where
+    x :: Int
+    x = 0
+
+    mx, my :: State Int :> es => Eff es (Env es)
+    mx = plusOne $ empty >> unsafeEff pure
+    my = plusOne $ put (2 :: Int) >> unsafeEff pure
+
+----------------------------------------
+-- Helper
+
+plusOne :: State Int :> es => Eff es a -> Eff es a
+plusOne = interpose @(State Int) $ \localEnv -> \case
+  Get -> send Get
+  Put i -> send (Put (i + 1))
+  State f -> send (State (second (+1) . f))
+  StateM f -> localSeqUnlift localEnv $ \runLocal ->
+    send (StateM (fmap (second (+1)) . runLocal . f))

--- a/effectful/tests/Main.hs
+++ b/effectful/tests/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Tasty
 
+import AlternativeTests
 import AsyncTests
 import ConcurrencyTests
 import EnvTests
@@ -15,7 +16,8 @@ import UnliftTests
 
 main :: IO ()
 main = defaultMain $ testGroup "effectful"
-  [ asyncTests
+  [ alternativeTests
+  , asyncTests
   , concurrencyTests
   , envTests
   , environmentTests


### PR DESCRIPTION
This PR adds two new instances `Alternative (Eff es)` and `MonadPlus (Eff es)`. In the case of alternative `mx <|> my` we proceed as follows:
 1. For the left branch `mx`: Create a copy of the current environment, run the branch with that environment, and on success overwrite the current environment with the copy.
 2. If the left branch fails, run the right one.
 
`empty` throws a new exception that was added to the library: `data AlternativeException = EmptyAlternative`. Note that this not as safe as the approach chosen for `MonadFail`: Here, using the instance requires the `Fail` effect to be in scope that handles the failure. The idea behind `AlternativeException` was that it should be easy to write something like `foo <|> bar <|> pure default` without having to deal with the empty case explicitly. Whether this is a good idea is of course up for debate :slightly_smiling_face: 