### PR TITLE
Make withEffToIO explicitly take an unlifting strategy

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -1,3 +1,9 @@
+# effectful-core-2.3.0.0 (2023-??-??)
+* Deprecate `withConcEffToIO`.
+* Make `withEffToIO` take an explicit unlifting strategy for the sake of
+  consistency with unlifting functions from `Effectful.Dispatch.Dynamic` and
+  easier to understand API.
+
 # effectful-core-2.2.2.2 (2023-03-13)
 * Allow `inject` to turn a monomorphic effect stack into a polymorphic one.
 * Use C sources only with GHC < 9.

--- a/effectful-core/effectful-core.cabal
+++ b/effectful-core/effectful-core.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 build-type:         Simple
 name:               effectful-core
-version:            2.2.2.2
+version:            2.3.0.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Control

--- a/effectful-core/src/Effectful.hs
+++ b/effectful-core/src/Effectful.hs
@@ -44,8 +44,8 @@ module Effectful
   , Limit(..)
   , unliftStrategy
   , withUnliftStrategy
-  , withEffToIO
   , withSeqEffToIO
+  , withEffToIO
   , withConcEffToIO
 
     -- ** Lifting
@@ -160,9 +160,9 @@ import Effectful.Internal.Monad
 -- If a library operates in 'IO', there are a couple of ways to integrate it.
 --
 -- The easiest way is to use its functions selectively in the 'Eff' monad with
--- the help of 'liftIO' or 'withEffToIO' / 'withRunInIO'. However, this is not
--- particularly robust, since it vastly broadens the scope in which the 'IOE'
--- effect is needed (not to mention that explicit lifting is annoying).
+-- the help of 'liftIO' or 'withEffToIO'. However, this is not particularly
+-- robust, since it vastly broadens the scope in which the 'IOE' effect is
+-- needed (not to mention that explicit lifting is annoying).
 --
 -- A somewhat better approach is to create a dummy static effect with
 -- lightweight wrappers of the library functions. As an example have a look at

--- a/effectful-core/src/Effectful/Internal/Unlift.hs
+++ b/effectful-core/src/Effectful/Internal/Unlift.hs
@@ -36,8 +36,8 @@ import Effectful.Internal.Utils
 -- Unlift strategies
 
 -- | The strategy to use when unlifting 'Effectful.Eff' computations via
--- 'Effectful.withEffToIO', 'Effectful.withRunInIO' or the
--- 'Effectful.Dispatch.Dynamic.localUnlift' family.
+-- 'Effectful.withEffToIO' or the 'Effectful.Dispatch.Dynamic.localUnlift'
+-- family.
 data UnliftStrategy
   = SeqUnlift
   -- ^ The fastest strategy and a default setting for t'Effectful.IOE'. An

--- a/effectful/CHANGELOG.md
+++ b/effectful/CHANGELOG.md
@@ -1,3 +1,9 @@
+# effectful-2.3.0.0 (2023-??-??)
+* Deprecate `withConcEffToIO`.
+* Make `withEffToIO` take an explicit unlifting strategy for the sake of
+  consistency with unlifting functions from `Effectful.Dispatch.Dynamic` and
+  easier to understand API.
+
 # effectful-2.2.2.0 (2023-01-11)
 * Add `withSeqEffToIO` and `withConcEffToIO` to `Effectful`.
 * Use strict `IORef` and `MVar` variants where appropriate.

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 build-type:         Simple
 name:               effectful
-version:            2.2.2.0
+version:            2.3.0.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Control
@@ -67,7 +67,7 @@ library
                     , async               >= 2.2.2
                     , bytestring          >= 0.10
                     , directory           >= 1.3.2
-                    , effectful-core      >= 2.2.2.0   && < 2.2.3.0
+                    , effectful-core      >= 2.3.0.0   && < 2.3.1.0
                     , process             >= 1.6.9
 
                     , time                >= 1.9.2

--- a/effectful/tests/UnliftTests.hs
+++ b/effectful/tests/UnliftTests.hs
@@ -28,59 +28,52 @@ test_threadStrategy :: Assertion
 test_threadStrategy = runEff $ do
   let strategy = ConcUnlift Ephemeral Unlimited
   s <- withUnliftStrategy strategy $ do
-    withEffToIO $ \runInIO -> do
+    withRunInIO $ \runInIO -> do
       inThread $ runInIO unliftStrategy
   U.assertEqual "correct strategy" strategy s
 
 test_seqUnliftInNewThread :: Assertion
 test_seqUnliftInNewThread = runEff $ do
   assertThrowsUnliftError "InvalidUseOfSeqUnlift error" $ do
-    withUnliftStrategy SeqUnlift $ do
-      withEffToIO $ \runInIO -> do
-        inThread $ runInIO $ return ()
+    withEffToIO SeqUnlift $ \runInIO -> do
+      inThread $ runInIO $ return ()
 
 test_ephemeralInvalid :: Assertion
 test_ephemeralInvalid = runEff $ do
   assertThrowsUnliftError "InvalidNumberOfUses error" $ do
-    withUnliftStrategy (ConcUnlift Ephemeral $ Limited 0) $ do
-      withEffToIO $ \_ -> return ()
+    withEffToIO (ConcUnlift Ephemeral $ Limited 0) $ \_ -> return ()
 
 test_ephemeralSameThread :: Assertion
 test_ephemeralSameThread = runEff $ do
   assertThrowsUnliftError "ExceededNumberOfUses error" $ do
-    withUnliftStrategy (ConcUnlift Ephemeral $ Limited 1) $ do
-      withEffToIO $ \runInIO -> inThread $ do
-        runInIO $ return ()
-        runInIO $ return ()
+    withEffToIO (ConcUnlift Ephemeral $ Limited 1) $ \runInIO -> inThread $ do
+      runInIO $ return ()
+      runInIO $ return ()
 
 test_ephemeralMultipleThreads :: Assertion
 test_ephemeralMultipleThreads = runEff $ do
   assertThrowsUnliftError "ExceededNumberOfUses error" $ do
-    withUnliftStrategy (ConcUnlift Ephemeral $ Limited 1) $ do
-      withEffToIO $ \runInIO -> do
-        inThread $ runInIO $ return ()
-        inThread $ runInIO $ return ()
+    withEffToIO (ConcUnlift Ephemeral $ Limited 1) $ \runInIO -> do
+      inThread $ runInIO $ return ()
+      inThread $ runInIO $ return ()
 
 test_persistentInvalid :: Assertion
 test_persistentInvalid = runEff $ do
   assertThrowsUnliftError "InvalidNumberOfThreads error" $ do
-    withUnliftStrategy (ConcUnlift Persistent $ Limited 0) $ do
-      withEffToIO $ \_ -> return ()
+    withEffToIO (ConcUnlift Persistent $ Limited 0) $ \_ -> return ()
 
 test_persistentSameThread :: Assertion
 test_persistentSameThread = runEff $ do
-  withUnliftStrategy (ConcUnlift Persistent $ Limited 1) $ do
-    withEffToIO $ \runInIO -> inThread $ do
-      runInIO $ return ()
-      runInIO $ return ()
+  withEffToIO (ConcUnlift Persistent $ Limited 1) $ \runInIO -> inThread $ do
+    runInIO $ return ()
+    runInIO $ return ()
 
 test_persistentMultipleThreads :: Assertion
 test_persistentMultipleThreads = runEff $ do
   assertThrowsUnliftError "ExceededNumberOfThreads error" $ do
-    withUnliftStrategy (ConcUnlift Persistent $ Limited 1) $ do
-      withEffToIO $ \runInIO -> do
-        inThread $ runInIO $ return ()
-        inThread $ runInIO $ return ()
+    withEffToIO (ConcUnlift Persistent $ Limited 1) $ \runInIO -> do
+      inThread $ runInIO $ return ()
+      inThread $ runInIO $ return ()
 
 ----------------------------------------
 -- Helpers


### PR DESCRIPTION
I've been slightly dissatisfied with discrepancy between `withEffToIO` and local unlifting functions from `Effectful.Dispatch.Dynamic`, even more so since #113.

I've also noticed that unlifting strategies can confuse people and the fact that `withRunInIO` and `withEffToIO` implicitly take its strategy from the `IOE` context doesn't help.

`withRunInIO` can't be fixed as it comes from `MonadUnliftIO`, but `withEffToIO` can. Sadly it's a (minor) breaking change, but should be worth it in the long run.