### PR TITLE
Add the SyncUnlift strategy

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -5,6 +5,9 @@
   easier to understand API.
 * Add support for turning an effect handler into an effectful operation via the
   `Provider` effect.
+* Add the `SyncUnlift` strategy for cases where running unlifted computations in
+  different threads is an implementation detail and concurrency is not
+  observable from outside.
 
 # effectful-core-2.2.2.2 (2023-03-13)
 * Allow `inject` to turn a monomorphic effect stack into a polymorphic one.

--- a/effectful-core/effectful-core.cabal
+++ b/effectful-core/effectful-core.cabal
@@ -64,6 +64,7 @@ library
                     , exceptions          >= 0.10.4
                     , monad-control       >= 1.0.3
                     , primitive           >= 0.7.3.0
+                    , stm                 >= 2.5
                     , transformers-base   >= 0.4.6
                     , unliftio-core       >= 0.2.0.1
 

--- a/effectful-core/src/Effectful.hs
+++ b/effectful-core/src/Effectful.hs
@@ -40,6 +40,7 @@ module Effectful
 
     -- ** Unlifting
   , UnliftStrategy(..)
+  , SyncPolicy(..)
   , Persistence(..)
   , Limit(..)
   , unliftStrategy

--- a/effectful-core/src/Effectful/Dispatch/Dynamic.hs
+++ b/effectful-core/src/Effectful/Dispatch/Dynamic.hs
@@ -499,6 +499,9 @@ localUnlift (LocalEnv les) strategy k = case strategy of
   SeqUnlift -> unsafeEff $ \es -> do
     seqUnliftIO les $ \unlift -> do
       (`unEff` es) $ k $ unsafeEff_ . unlift
+  SyncUnlift p -> unsafeEff $ \es -> do
+    syncUnliftIO les p $ \unlift -> do
+      (`unEff` es) $ k $ unsafeEff_ . unlift
   ConcUnlift p l -> unsafeEff $ \es -> do
     concUnliftIO les p l $ \unlift -> do
       (`unEff` es) $ k $ unsafeEff_ . unlift
@@ -514,6 +517,7 @@ localUnliftIO
   -> Eff es a
 localUnliftIO (LocalEnv les) strategy k = case strategy of
   SeqUnlift      -> liftIO $ seqUnliftIO les k
+  SyncUnlift p   -> liftIO $ syncUnliftIO les p k
   ConcUnlift p l -> liftIO $ concUnliftIO les p l k
 
 ----------------------------------------
@@ -552,6 +556,9 @@ localLift !_ strategy k = case strategy of
   -- localEs type variable. It's also strict so that callers don't cheat.
   SeqUnlift -> unsafeEff $ \es -> do
     seqUnliftIO es $ \unlift -> do
+      (`unEff` es) $ k $ unsafeEff_ . unlift
+  SyncUnlift p -> unsafeEff $ \es -> do
+    syncUnliftIO es p $ \unlift -> do
       (`unEff` es) $ k $ unsafeEff_ . unlift
   ConcUnlift p l -> unsafeEff $ \es -> do
     concUnliftIO es p l $ \unlift -> do
@@ -642,6 +649,10 @@ localLiftUnlift (LocalEnv les) strategy k = case strategy of
     seqUnliftIO es $ \unliftEs -> do
       seqUnliftIO les $ \unliftLocalEs -> do
         (`unEff` es) $ k (unsafeEff_ . unliftEs) (unsafeEff_ . unliftLocalEs)
+  SyncUnlift p -> unsafeEff $ \es -> do
+    syncUnliftIO es p $ \unliftEs -> do
+      syncUnliftIO les p $ \unliftLocalEs -> do
+        (`unEff` es) $ k (unsafeEff_ . unliftEs) (unsafeEff_ . unliftLocalEs)
   ConcUnlift p l -> unsafeEff $ \es -> do
     concUnliftIO es p l $ \unliftEs -> do
       concUnliftIO les p l $ \unliftLocalEs -> do
@@ -665,6 +676,7 @@ localLiftUnliftIO
   -> Eff es a
 localLiftUnliftIO (LocalEnv les) strategy k = case strategy of
   SeqUnlift      -> liftIO $ seqUnliftIO les $ k unsafeEff_
+  SyncUnlift p   -> liftIO $ syncUnliftIO les p $ k unsafeEff_
   ConcUnlift p l -> liftIO $ concUnliftIO les p l $ k unsafeEff_
 
 ----------------------------------------

--- a/effectful/CHANGELOG.md
+++ b/effectful/CHANGELOG.md
@@ -5,6 +5,9 @@
   easier to understand API.
 * Add support for turning an effect handler into an effectful operation via the
   `Provider` effect.
+* Add the `SyncUnlift` strategy for cases where running unlifted computations in
+  different threads is an implementation detail and concurrency is not
+  observable from outside.
 
 # effectful-2.2.2.0 (2023-01-11)
 * Add `withSeqEffToIO` and `withConcEffToIO` to `Effectful`.

--- a/effectful/tests/UnliftTests.hs
+++ b/effectful/tests/UnliftTests.hs
@@ -1,17 +1,25 @@
 module UnliftTests (unliftTests) where
 
+import Control.Concurrent
 import Control.Exception
+import Data.Functor
 import Test.Tasty
 import Test.Tasty.HUnit
 import qualified UnliftIO.Async as A
 
 import Effectful
+import Effectful.State.Dynamic
 import qualified Utils as U
 
 unliftTests :: TestTree
 unliftTests = testGroup "Unlift"
   [ testCase "Strategy stays the same in a new thread" test_threadStrategy
   , testCase "SeqUnlift in new thread" test_seqUnliftInNewThread
+  , testGroup "SyncUnlift"
+    [ testCase "SyncError works" test_syncErrorWorks
+    , testCase "SyncError throws when appropriate" test_syncErrorThrows
+    , testCase "SyncWait works" test_syncWaitWorks
+    ]
   , testGroup "Ephemeral strategy"
     [ testCase "Invalid limit" test_ephemeralInvalid
     , testCase "Uses in same thread" test_ephemeralSameThread
@@ -37,6 +45,33 @@ test_seqUnliftInNewThread = runEff $ do
   assertThrowsUnliftError "InvalidUseOfSeqUnlift error" $ do
     withEffToIO SeqUnlift $ \runInIO -> do
       inThread $ runInIO $ return ()
+
+test_syncErrorWorks :: Assertion
+test_syncErrorWorks = runEff . evalStateLocal @Int 1 $ do
+  modifyFromAsync (*2)
+  modifyFromAsync (*3)
+  U.assertEqual "correct state" 6 =<< get @Int
+  where
+    modifyFromAsync f = withEffToIO (SyncUnlift SyncError) $ \runInIO -> do
+      void . A.async . runInIO $ liftIO (threadDelay 10000) >> modify @Int f
+      -- Wait for the async action to start, but try exiting the scope of
+      -- withEffToIO before the unlifted computation had a chance to finish to
+      -- check that it waits until it does.
+      threadDelay 1000
+
+test_syncErrorThrows :: Assertion
+test_syncErrorThrows = runEff $ do
+  assertThrowsUnliftError "Sync error" $ do
+    withEffToIO (SyncUnlift SyncError) $ \runInIO -> do
+      A.race_ (runInIO . liftIO $ threadDelay 10000)
+              (runInIO . liftIO $ threadDelay 10000)
+
+test_syncWaitWorks :: Assertion
+test_syncWaitWorks = runEff . evalStateLocal @Int 0 $ do
+  withEffToIO (SyncUnlift SyncWait) $ \runInIO -> do
+    -- SyncUnlift SyncWait turns concurrent code into sequential code.
+    A.replicateConcurrently_ 100 $ runInIO $ modify @Int (+1)
+  U.assertEqual "correct state" 100 =<< get @Int
 
 test_ephemeralInvalid :: Assertion
 test_ephemeralInvalid = runEff $ do


### PR DESCRIPTION
Turns out that lifting functions that e.g. employ a worker thread to run an unlifted argument is a bit problematic at the moment, because their control flow is observably sequential, but SeqUnlift doesn't work with them.

This bridges the gap.
