### PR TITLE
Generate wildcard type parameters

### DIFF
--- a/effectful-th/src/Effectful/TH.hs
+++ b/effectful-th/src/Effectful/TH.hs
@@ -76,7 +76,7 @@ makeEffectImpl makeSig effName = do
   checkRequiredExtensions
   info <- reifyDatatype effName
   dispatch <- do
-    e <- getEff (ConT $ datatypeName info) (datatypeInstTypes info)
+    e <- getEff (ConT $ datatypeName info) (const WildCardT <$> datatypeInstTypes info)
     let dispatchE = ConT ''DispatchOf `AppT` e
         dynamic   = PromotedT 'Dynamic
     pure . TySynInstD $ TySynEqn Nothing dispatchE dynamic


### PR DESCRIPTION
Consider the following code:
```
data Output (o :: GHC.Type) :: Effect where
  Output :: o -> Output o m ()

makeEffectLib ''Output
```
Compiling this with warnings turned on generates the following warning:
```
warning: [GHC-40910] [-Wunused-type-patterns]
    Defined but not used on the right hand side: type variable ‘o’
   |
12 | makeEffectLib ''Output
```

This is because the generated definition looks like this:
```
type instance DispatchOf (Output o) = 'Dynamic
```
And the variable `o` is not used in the rhs.

To fix this, I've substituted all type variables with wildcard, so the generated code would look like this instead:
```
type instance DispatchOf (Output _) = 'Dynamic
```
