### PR TITLE
Get haddock for makeEffect from the declaration

### DIFF
--- a/effectful-th/tests/ThTests.hs
+++ b/effectful-th/tests/ThTests.hs
@@ -16,6 +16,7 @@ main = pure () -- only compilation tests
 data SimpleADT (m :: Type -> Type) (a :: Type)
   = SimpleADTC1 Int
   | SimpleADTC2 String
+  -- ^ This one does the second thing
 
 -- Test generation of fixity information.
 infixl 1 `SimpleADTC1`
@@ -40,6 +41,7 @@ makeEffect ''ADTSyntax3
 
 data GADTSyntax :: Effect where
   GADTSyntaxC1 :: Int -> GADTSyntax m Int
+  -- | I am documented
   GADTSyntaxC2 :: String -> GADTSyntax m String
   GADTSyntaxC3 :: IOE :> es => Bool -> GADTSyntax (Eff es) a
 


### PR DESCRIPTION
Fixes #225

I went ahead and put together a PR, since it's very simple.

I can't see a good way to test this, but you can verify by opening the test file in HLS, adding some references to the sending functions, and checking that they have the right haddock in the hover.