### PR TITLE
Utility functions for handling effects

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# effectful-core-2.4.0.0 (????-??-??)
+* Add utility functions for handling first order effects to
+  `Effectful.Dispatch.Dynamic`.
+
 # effectful-core-2.3.1.0 (2024-06-07)
 * Drop support for GHC 8.8.
 * Remove inaccurate information from the `Show` instance of `ErrorWrapper`.

--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -1,4 +1,6 @@
 # effectful-core-2.4.0.0 (????-??-??)
+* Add utility functions for handling effects that take the effect handler as the
+  last parameter to `Effectful.Dispatch.Dynamic`.
 * Add utility functions for handling first order effects to
   `Effectful.Dispatch.Dynamic`.
 

--- a/effectful-core/effectful-core.cabal
+++ b/effectful-core/effectful-core.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 build-type:         Simple
 name:               effectful-core
-version:            2.3.1.0
+version:            2.4.0.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Control

--- a/effectful-core/src/Effectful/Dispatch/Dynamic.hs
+++ b/effectful-core/src/Effectful/Dispatch/Dynamic.hs
@@ -595,7 +595,7 @@ imposeWith runHandlerEs m handler = impose runHandlerEs handler m
 -- | Type signature of a first order effect handler.
 --
 -- @since 2.4.0.0
-type EffectHandler_ e es
+type EffectHandler_ (e :: Effect) (es :: [Effect])
   = forall a localEs. HasCallStack
   => e (Eff localEs) a
   -- ^ The operation.

--- a/effectful-core/src/Effectful/Fail.hs
+++ b/effectful-core/src/Effectful/Fail.hs
@@ -15,10 +15,10 @@ import Effectful.Internal.Monad (Fail(..))
 
 -- | Run the 'Fail' effect via 'Error'.
 runFail :: Eff (Fail : es) a -> Eff es (Either String a)
-runFail = reinterpret runErrorNoCallStack $ \_ -> \case
+runFail = reinterpret_ runErrorNoCallStack $ \case
   Fail msg -> throwError msg
 
 -- | Run the 'Fail' effect via the 'MonadFail' instance for 'IO'.
 runFailIO :: IOE :> es => Eff (Fail : es) a -> Eff es a
-runFailIO = interpret $ \_ -> \case
+runFailIO = interpret_ $ \case
   Fail msg -> liftIO $ fail msg

--- a/effectful-core/src/Effectful/Internal/Monad.hs
+++ b/effectful-core/src/Effectful/Internal/Monad.hs
@@ -500,7 +500,7 @@ type EffectHandler e es
   -- ^ Capture of the local environment for handling local 'Eff' computations
   -- when @e@ is a higher order effect.
   -> e (Eff localEs) a
-  -- ^ The effect performed in the local environment.
+  -- ^ The operation.
   -> Eff es a
 
 -- | An internal representation of dynamically dispatched effects, i.e. the

--- a/effectful-core/src/Effectful/Internal/Monad.hs
+++ b/effectful-core/src/Effectful/Internal/Monad.hs
@@ -494,7 +494,7 @@ type role LocalEnv nominal nominal
 newtype LocalEnv (localEs :: [Effect]) (handlerEs :: [Effect]) = LocalEnv (Env localEs)
 
 -- | Type signature of the effect handler.
-type EffectHandler e es
+type EffectHandler (e :: Effect) (es :: [Effect])
   = forall a localEs. (HasCallStack, e :> localEs)
   => LocalEnv localEs es
   -- ^ Capture of the local environment for handling local 'Eff' computations

--- a/effectful-core/src/Effectful/Provider.hs
+++ b/effectful-core/src/Effectful/Provider.hs
@@ -74,7 +74,7 @@ import Effectful.Internal.Utils
 --     => FilePath
 --     -> Eff (Write : es) a
 --     -> Eff es a
---   runWriteIO fp = interpret $ \_ -> \case
+--   runWriteIO fp = interpret_ $ \case
 --     Write msg -> liftIO . putStrLn $ fp ++ ": " ++ msg
 -- :}
 --
@@ -84,7 +84,7 @@ import Effectful.Internal.Utils
 --     => FilePath
 --     -> Eff (Write : es) a
 --     -> Eff es a
---   runWritePure fp = interpret $ \_ -> \case
+--   runWritePure fp = interpret_ $ \case
 --     Write msg -> modify $ M.insertWith (++) fp [msg]
 -- :}
 --

--- a/effectful-plugin/tests/PluginTests.hs
+++ b/effectful-plugin/tests/PluginTests.hs
@@ -96,7 +96,7 @@ data TaggedState k s :: Effect where
 type instance DispatchOf (TaggedState k s) = Dynamic
 
 runTaggedState :: s -> Eff (TaggedState k s : es) a -> Eff es (a, s)
-runTaggedState s = reinterpret (runState s) $ \_ -> \case
+runTaggedState s = reinterpret_ (runState s) $ \case
   TaggedGet    -> get
   TaggedPut s' -> put s'
 
@@ -112,5 +112,5 @@ data DBAction whichDb :: Effect where
 type instance DispatchOf (DBAction whichDb) = Dynamic
 
 runDBAction :: Eff (DBAction which : es) a -> Eff es a
-runDBAction = interpret $ \_ -> \case
+runDBAction = interpret_ $ \case
   DoSelect (Select a) -> pure $ Just a

--- a/effectful/CHANGELOG.md
+++ b/effectful/CHANGELOG.md
@@ -1,4 +1,6 @@
 # effectful-2.4.0.0 (????-??-??)
+* Add utility functions for handling effects that take the effect handler as the
+  last parameter to `Effectful.Dispatch.Dynamic`.
 * Add utility functions for handling first order effects to
   `Effectful.Dispatch.Dynamic`.
 

--- a/effectful/CHANGELOG.md
+++ b/effectful/CHANGELOG.md
@@ -1,3 +1,7 @@
+# effectful-2.4.0.0 (????-??-??)
+* Add utility functions for handling first order effects to
+  `Effectful.Dispatch.Dynamic`.
+
 # effectful-2.3.1.0 (2024-06-07)
 * Drop support for GHC 8.8.
 * Remove inaccurate information from the `Show` instance of `ErrorWrapper`.

--- a/effectful/bench/FileSizes.hs
+++ b/effectful/bench/FileSizes.hs
@@ -102,7 +102,7 @@ effectful_tryFileSize :: Effectful_File E.:> es => FilePath -> E.Eff es (Maybe I
 effectful_tryFileSize = E.send . Effectful_tryFileSize
 
 effectful_runFile :: E.IOE E.:> es => E.Eff (Effectful_File : es) a -> E.Eff es a
-effectful_runFile = E.interpret \_ -> \case
+effectful_runFile = E.interpret_ \case
   Effectful_tryFileSize path -> liftIO $ tryGetFileSize path
 
 data Effectful_Logging :: E.Effect where
@@ -116,7 +116,7 @@ effectful_logMsg = E.send . Effectful_logMsg . T.pack
 effectful_runLogging
   :: E.Eff (Effectful_Logging : es) a
   -> E.Eff es (a, [Text])
-effectful_runLogging = E.reinterpret (E.runState []) \_ -> \case
+effectful_runLogging = E.reinterpret_ (E.runState []) \case
   Effectful_logMsg msg -> E.modify (msg :)
 
 ----------

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 build-type:         Simple
 name:               effectful
-version:            2.3.1.0
+version:            2.4.0.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Control
@@ -69,7 +69,7 @@ library
                     , async               >= 2.2.2
                     , bytestring          >= 0.10
                     , directory           >= 1.3.2
-                    , effectful-core      >= 2.3.1.0   && < 2.3.2.0
+                    , effectful-core      >= 2.4.0.0   && < 2.4.1.0
                     , process             >= 1.6.9
 
                     , time                >= 1.9.2

--- a/effectful/tests/EnvTests.hs
+++ b/effectful/tests/EnvTests.hs
@@ -191,11 +191,11 @@ data A :: Effect where
 type instance DispatchOf A = Dynamic
 
 runA :: Int -> Eff (A : es) a -> Eff es a
-runA n = interpret $ \_ -> \case
+runA n = interpret_ $ \case
   A -> pure n
 
 doubleA :: A :> es => Eff es a -> Eff es a
-doubleA = interpose $ \_ -> \case
+doubleA = interpose_ $ \case
   A -> (+) <$> send A <*> send A
 
 data B :: Effect where
@@ -203,9 +203,9 @@ data B :: Effect where
 type instance DispatchOf B = Dynamic
 
 runB :: A :> es => Eff (B : es) a -> Eff es a
-runB = interpret $ \_ -> \case
+runB = interpret_ $ \case
   B -> send A
 
 doubleB :: B :> es => Eff es a -> Eff es a
-doubleB = interpose $ \_ -> \case
+doubleB = interpose_ $ \case
   B -> (+) <$> send B <*> send B

--- a/effectful/tests/ErrorTests.hs
+++ b/effectful/tests/ErrorTests.hs
@@ -42,5 +42,5 @@ outerThrow :: (HasCallStack, OuterThrow :> es) => Eff es ()
 outerThrow = send OuterThrow
 
 runOuterThrow :: Error String :> es => Eff (OuterThrow : es) a -> Eff es a
-runOuterThrow = interpret $ \_ -> \case
+runOuterThrow = interpret_ $ \case
   OuterThrow -> throwError "outer"

--- a/effectful/tests/NonDetTests.hs
+++ b/effectful/tests/NonDetTests.hs
@@ -84,7 +84,7 @@ outerEmpty :: (HasCallStack, OuterEmpty :> es) => Eff es a
 outerEmpty = send OuterEmpty
 
 runOuterEmpty :: NonDet :> es => Eff (OuterEmpty : es) a -> Eff es a
-runOuterEmpty = interpret $ \_ -> \case
+runOuterEmpty = interpret_ $ \case
   OuterEmpty -> emptyEff
 
 ----

--- a/effectful/tests/StateTests.hs
+++ b/effectful/tests/StateTests.hs
@@ -117,7 +117,7 @@ putInt = send . PutInt
 runHasInt :: Int -> Eff (HasInt : es) a -> Eff es a
 runHasInt n =
   -- reinterpret with redundant local effects
-  reinterpret (evalState () . evalState n . evalState True) $ \_ -> \case
+  reinterpret_ (evalState () . evalState n . evalState True) $ \case
     GetInt   -> get
     PutInt i -> put i
 


### PR DESCRIPTION
Supersedes #230.

@michaelpj @ocharles does that work for you?

I decided to go with `handleWith` instead of `interpretWith` since the name `interpretWith` is too close to `interpret` and might be confusing.

Still reads nicely:

```haskell
myFunction arg `handleWith_` \case
  NotifyA i -> ...
  NotifyB s -> ...
```

and won't clash with `Control.Monad.Catch`.