### PR TITLE
Improve Show instance of Effectful.Error.Static.ErrorWrapper

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -6,8 +6,16 @@
 * Improve `Effectful.Labeled`, add `Effectful.Labeled.Error`,
   `Effectful.Labeled.Reader`, `Effectful.Labeled.State` and
   `Effectful.Labeled.Writer`.
-* **Breaking change**: `localSeqLend`, `localLend`, `localSeqBorrow` and
-  `localBorrow` now take a list of effects instead of a single one.
+* Add `throwErrorWith` and `throwError_` to `Effectful.Error.Static` and
+  `Effectful.Error.Dynamic`.
+* **Breaking changes**:
+  - `localSeqLend`, `localLend`, `localSeqBorrow` and `localBorrow` now take a
+    list of effects instead of a single one.
+  - `Effectful.Error.Static.throwError` now requires the error type to have a
+    `Show` constraint. If this is not the case for some of your error types, use
+    `throwError_` for them.
+  - `ThrowError` operation from the dynamic version of the `Error` effect was
+    replaced with `ThrowErrorWith`.
 
 # effectful-core-2.3.1.0 (2024-06-07)
 * Drop support for GHC 8.8.

--- a/effectful-plugin/tests/PluginTests.hs
+++ b/effectful-plugin/tests/PluginTests.hs
@@ -63,7 +63,7 @@ oStrState = put "hello"
 err :: Error e :> es => Eff es Bool
 err =
   catchError
-    (throwError (error ""))
+    (throwError_ (error ""))
     (\_ _ -> pure True)
 
 errState :: (Num s, Error e :> es, State s :> es) => Eff es Bool

--- a/effectful/CHANGELOG.md
+++ b/effectful/CHANGELOG.md
@@ -6,8 +6,16 @@
 * Improve `Effectful.Labeled`, add `Effectful.Labeled.Error`,
   `Effectful.Labeled.Reader`, `Effectful.Labeled.State` and
   `Effectful.Labeled.Writer`.
-* **Breaking change**: `localSeqLend`, `localLend`, `localSeqBorrow` and
-  `localBorrow` now take a list of effects instead of a single one.
+* Add `throwErrorWith` and `throwError_` to `Effectful.Error.Static` and
+  `Effectful.Error.Dynamic`.
+* **Breaking changes**:
+  - `localSeqLend`, `localLend`, `localSeqBorrow` and `localBorrow` now take a
+    list of effects instead of a single one.
+  - `Effectful.Error.Static.throwError` now requires the error type to have a
+    `Show` constraint. If this is not the case for some of your error types, use
+    `throwError_` for them.
+  - `ThrowError` operation from the dynamic version of the `Error` effect was
+    replaced with `ThrowErrorWith`.
 
 # effectful-2.3.1.0 (2024-06-07)
 * Drop support for GHC 8.8.


### PR DESCRIPTION
For example, if a third-party library spawns worker threads and if a job throws, it simply catches SomeException, logs it and retries the job later, as of today internal exceptions representing errors of the `Error` effect wouldn't show any info about the error, just the backtrace.

This fixes it at the cost of small API breakage.

TODO changelog