### PR TITLE
Heftia countdown benchmarks

### DIFF
--- a/effectful-th/effectful-th.cabal
+++ b/effectful-th/effectful-th.cabal
@@ -62,7 +62,7 @@ library
                     , effectful-core      >= 1.0.0.0   && < 3.0.0.0
                     , exceptions          >= 0.10.4
                     , template-haskell    >= 2.16      && < 2.23
-                    , th-abstraction      >= 0.6       && < 0.8
+                    , th-abstraction      >= 0.4       && < 0.8
 
     hs-source-dirs:  src
 

--- a/effectful/bench/FileSizes.hs
+++ b/effectful/bench/FileSizes.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE UndecidableInstances #-}
 module FileSizes where
 
@@ -30,7 +31,7 @@ import Cleff.State qualified as C
 
 -- freer-simple
 #ifdef VERSION_freer_simple
-import Control.Monad.Freer qualified as FS
+import "freer-simple" Control.Monad.Freer qualified as FS
 import Control.Monad.Freer.Reader qualified as FS
 import Control.Monad.Freer.State qualified as FS
 #endif

--- a/effectful/bench/Main.hs
+++ b/effectful/bench/Main.hs
@@ -108,6 +108,20 @@ countdown n = bgroup (show n)
     , bench "deep"    $ nf countdownMtlDeep n
     ]
 #endif
+#ifdef VERSION_heftia_effects
+  , bgroup "heftia-effects (church)"
+    [ bench "shallow" $ nf countdownHeftiaChurch n
+    , bench "deep"    $ nf countdownHeftiaChurchDeep n
+    ]
+  , bgroup "heftia-effects (final)"
+    [ bench "shallow" $ nf countdownHeftiaFinal n
+    , bench "deep"    $ nf countdownHeftiaFinalDeep n
+    ]
+  , bgroup "heftia-effects (tree)"
+    [ bench "shallow" $ nf countdownHeftiaTree n
+    , bench "deep"    $ nf countdownHeftiaTreeDeep n
+    ]
+#endif
 #ifdef VERSION_fused_effects
   , bgroup "fused-effects"
     [ bench "shallow" $ nf countdownFusedEffects n

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -188,6 +188,12 @@ benchmark bench
        if impl(ghc < 9.11)
           build-depends: polysemy >= 1.9.2.0
 
+       if impl(ghc < 9.11)
+          build-depends: data-effects >= 0.1.2.0
+                       , data-effects-core >= 0.1.0.0
+                       , heftia >= 0.3.1.0
+                       , heftia-effects >= 0.3.1.0
+
     build-depends:    base
                     , async
                     , effectful


### PR DESCRIPTION
```
package effectful
  flags: +benchmark-foreign-libraries
``` 

in `cabal.project.local` and `cabal run bench -- --pattern '$2 == "countdown" && $3 == "1000"' --svg bench_countdown_1000.svg` to reproduce (GHC 9.2.8).

![bench_countdown_1000](https://github.com/user-attachments/assets/8808443d-8894-417e-ab90-bef333b928a1)

I'm not merging this because these packages have way too restrictive bounds and pull in tons of deps, I was just curious.