### PR TITLE
Add HasCallStack constraints for easier debugging

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix a bug in `stateM` and `modifyM` of thread local `State` effect that
   might've caused dropped state updates
   ([#237](https://github.com/haskell-effectful/effectful/issues/237)).
+* Add `HasCallStack` constraints for easier debugging.
 * **Breaking changes**:
   - `localSeqLend`, `localLend`, `localSeqBorrow` and `localBorrow` now take a
     list of effects instead of a single one.

--- a/effectful-core/src/Effectful/Dispatch/Dynamic.hs
+++ b/effectful-core/src/Effectful/Dispatch/Dynamic.hs
@@ -428,7 +428,7 @@ import Effectful.Internal.Utils
 -- /Note:/ 'interpret' can be turned into a 'reinterpret' with the use of
 -- 'inject'.
 interpret
-  :: DispatchOf e ~ Dynamic
+  :: (HasCallStack, DispatchOf e ~ Dynamic)
   => EffectHandler e es
   -- ^ The effect handler.
   -> Eff (e : es) a
@@ -442,7 +442,7 @@ interpret handler m = unsafeEff $ \es -> do
 --
 -- @since 2.4.0.0
 interpretWith
-  :: DispatchOf e ~ Dynamic
+  :: (HasCallStack, DispatchOf e ~ Dynamic)
   => Eff (e : es) a
   -> EffectHandler e es
   -- ^ The effect handler.
@@ -453,7 +453,7 @@ interpretWith m handler = interpret handler m
 --
 -- @'interpret' ≡ 'reinterpret' 'id'@
 reinterpret
-  :: DispatchOf e ~ Dynamic
+  :: (HasCallStack, DispatchOf e ~ Dynamic)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> EffectHandler e handlerEs
@@ -470,7 +470,7 @@ reinterpret runHandlerEs handler m = unsafeEff $ \es -> do
 --
 -- @since 2.4.0.0
 reinterpretWith
-  :: DispatchOf e ~ Dynamic
+  :: (HasCallStack, DispatchOf e ~ Dynamic)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> Eff (e : es) a
@@ -508,7 +508,7 @@ reinterpretWith runHandlerEs m handler = reinterpret runHandlerEs handler m
 -- op
 --
 interpose
-  :: forall e es a. (DispatchOf e ~ Dynamic, e :> es)
+  :: forall e es a. (HasCallStack, DispatchOf e ~ Dynamic, e :> es)
   => EffectHandler e es
   -- ^ The effect handler.
   -> Eff es a
@@ -537,7 +537,7 @@ interpose handler m = unsafeEff $ \es -> do
 --
 -- @since 2.4.0.0
 interposeWith
-  :: (DispatchOf e ~ Dynamic, e :> es)
+  :: (HasCallStack, DispatchOf e ~ Dynamic, e :> es)
   => Eff es a
   -> EffectHandler e es
   -- ^ The effect handler.
@@ -549,7 +549,7 @@ interposeWith m handler = interpose handler m
 --
 -- @'interpose' ≡ 'impose' 'id'@
 impose
-  :: forall e es handlerEs a b. (DispatchOf e ~ Dynamic, e :> es)
+  :: forall e es handlerEs a b. (HasCallStack, DispatchOf e ~ Dynamic, e :> es)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> EffectHandler e handlerEs
@@ -582,7 +582,7 @@ impose runHandlerEs handler m = unsafeEff $ \es -> do
 --
 -- @since 2.4.0.0
 imposeWith
-  :: (DispatchOf e ~ Dynamic, e :> es)
+  :: (HasCallStack, DispatchOf e ~ Dynamic, e :> es)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> Eff es a
@@ -607,7 +607,7 @@ type EffectHandler_ (e :: Effect) (es :: [Effect])
 --
 -- @since 2.4.0.0
 interpret_
-  :: DispatchOf e ~ Dynamic
+  :: (HasCallStack, DispatchOf e ~ Dynamic)
   => EffectHandler_ e es
   -- ^ The effect handler.
   -> Eff (e : es) a
@@ -618,7 +618,7 @@ interpret_ handler = interpret (const handler)
 --
 -- @since 2.4.0.0
 interpretWith_
-  :: DispatchOf e ~ Dynamic
+  :: (HasCallStack, DispatchOf e ~ Dynamic)
   => Eff (e : es) a
   -> EffectHandler_ e es
   -- ^ The effect handler.
@@ -629,7 +629,7 @@ interpretWith_ m handler = interpretWith m (const handler)
 --
 -- @since 2.4.0.0
 reinterpret_
-  :: DispatchOf e ~ Dynamic
+  :: (HasCallStack, DispatchOf e ~ Dynamic)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> EffectHandler_ e handlerEs
@@ -642,7 +642,7 @@ reinterpret_ runHandlerEs handler = reinterpret runHandlerEs (const handler)
 --
 -- @since 2.4.0.0
 reinterpretWith_
-  :: DispatchOf e ~ Dynamic
+  :: (HasCallStack, DispatchOf e ~ Dynamic)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> Eff (e : es) a
@@ -655,7 +655,7 @@ reinterpretWith_ runHandlerEs m handler = reinterpretWith runHandlerEs m (const 
 --
 -- @since 2.4.0.0
 interpose_
-  :: (DispatchOf e ~ Dynamic, e :> es)
+  :: (HasCallStack, DispatchOf e ~ Dynamic, e :> es)
   => EffectHandler_ e es
   -- ^ The effect handler.
   -> Eff es a
@@ -666,7 +666,7 @@ interpose_ handler = interpose (const handler)
 --
 -- @since 2.4.0.0
 interposeWith_
-  :: (DispatchOf e ~ Dynamic, e :> es)
+  :: (HasCallStack, DispatchOf e ~ Dynamic, e :> es)
   => Eff es a
   -> EffectHandler_ e es
   -- ^ The effect handler.
@@ -677,7 +677,7 @@ interposeWith_ m handler = interposeWith m (const handler)
 --
 -- @since 2.4.0.0
 impose_
-  :: (DispatchOf e ~ Dynamic, e :> es)
+  :: (HasCallStack, DispatchOf e ~ Dynamic, e :> es)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> EffectHandler_ e handlerEs
@@ -690,7 +690,7 @@ impose_ runHandlerEs handler = impose runHandlerEs (const handler)
 --
 -- @since 2.4.0.0
 imposeWith_
-  :: (DispatchOf e ~ Dynamic, e :> es)
+  :: (HasCallStack, DispatchOf e ~ Dynamic, e :> es)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> Eff es a
@@ -960,7 +960,7 @@ localLiftUnliftIO (LocalEnv les) strategy k = case strategy of
 -- @since 2.4.0.0
 localSeqLend
   :: forall lentEs es handlerEs localEs a
-   . (KnownSubset lentEs es, SharedSuffix es handlerEs)
+   . (HasCallStack, KnownSubset lentEs es, SharedSuffix es handlerEs)
   => LocalEnv localEs handlerEs
   -> ((forall r. Eff (lentEs ++ localEs) r -> Eff localEs r) -> Eff es a)
   -- ^ Continuation with the lent handler in scope.
@@ -977,7 +977,7 @@ localSeqLend (LocalEnv les) k = unsafeEff $ \es -> do
 -- @since 2.4.0.0
 localLend
   :: forall lentEs es handlerEs localEs a
-   . (KnownSubset lentEs es, SharedSuffix es handlerEs)
+   . (HasCallStack, KnownSubset lentEs es, SharedSuffix es handlerEs)
   => LocalEnv localEs handlerEs
   -> UnliftStrategy
   -> ((forall r. Eff (lentEs ++ localEs) r -> Eff localEs r) -> Eff es a)
@@ -997,7 +997,7 @@ localLend (LocalEnv les) strategy k = case strategy of
 -- @since 2.4.0.0
 localSeqBorrow
   :: forall borrowedEs es handlerEs localEs a
-   . (KnownSubset borrowedEs localEs, SharedSuffix es handlerEs)
+   . (HasCallStack, KnownSubset borrowedEs localEs, SharedSuffix es handlerEs)
   => LocalEnv localEs handlerEs
   -> ((forall r. Eff (borrowedEs ++ es) r -> Eff es r) -> Eff es a)
   -- ^ Continuation with the borrowed handler in scope.
@@ -1015,7 +1015,7 @@ localSeqBorrow (LocalEnv les) k = unsafeEff $ \es -> do
 -- @since 2.4.0.0
 localBorrow
   :: forall borrowedEs es handlerEs localEs a
-   . (KnownSubset borrowedEs localEs, SharedSuffix es handlerEs)
+   . (HasCallStack, KnownSubset borrowedEs localEs, SharedSuffix es handlerEs)
   => LocalEnv localEs handlerEs
   -> UnliftStrategy
   -> ((forall r. Eff (borrowedEs ++ es) r -> Eff es r) -> Eff es a)

--- a/effectful-core/src/Effectful/Error/Dynamic.hs
+++ b/effectful-core/src/Effectful/Error/Dynamic.hs
@@ -44,7 +44,8 @@ type instance DispatchOf (Error e) = Dynamic
 
 -- | Handle errors of type @e@ (via "Effectful.Error.Static").
 runError
-  :: Eff (Error e : es) a
+  :: HasCallStack
+  => Eff (Error e : es) a
   -> Eff es (Either (E.CallStack, e) a)
 runError = reinterpret E.runError $ \env -> \case
   ThrowErrorWith display e -> E.throwErrorWith display e
@@ -56,7 +57,8 @@ runError = reinterpret E.runError $ \env -> \case
 --
 -- @since 2.3.0.0
 runErrorWith
-  :: (E.CallStack -> e -> Eff es a)
+  :: HasCallStack
+  => (E.CallStack -> e -> Eff es a)
   -- ^ The error handler.
   -> Eff (Error e : es) a
   -> Eff es a
@@ -69,14 +71,16 @@ runErrorWith handler m = runError m >>= \case
 --
 -- @since 2.3.0.0
 runErrorNoCallStack
-  :: Eff (Error e : es) a
+  :: HasCallStack
+  => Eff (Error e : es) a
   -> Eff es (Either e a)
 runErrorNoCallStack = fmap (either (Left . snd) Right) . runError
 
 -- | Handle errors of type @e@ (via "Effectful.Error.Static") with a specific
 -- error handler. In case of an error discard the 'CallStack'.
 runErrorNoCallStackWith
-  :: (e -> Eff es a)
+  :: HasCallStack
+  => (e -> Eff es a)
   -- ^ The error handler.
   -> Eff (Error e : es) a
   -> Eff es a

--- a/effectful-core/src/Effectful/Fail.hs
+++ b/effectful-core/src/Effectful/Fail.hs
@@ -14,11 +14,11 @@ import Effectful.Error.Static
 import Effectful.Internal.Monad (Fail(..))
 
 -- | Run the 'Fail' effect via 'Error'.
-runFail :: Eff (Fail : es) a -> Eff es (Either String a)
+runFail :: HasCallStack => Eff (Fail : es) a -> Eff es (Either String a)
 runFail = reinterpret_ runErrorNoCallStack $ \case
   Fail msg -> throwError msg
 
 -- | Run the 'Fail' effect via the 'MonadFail' instance for 'IO'.
-runFailIO :: IOE :> es => Eff (Fail : es) a -> Eff es a
+runFailIO :: (HasCallStack, IOE :> es) => Eff (Fail : es) a -> Eff es a
 runFailIO = interpret_ $ \case
   Fail msg -> liftIO $ fail msg

--- a/effectful-core/src/Effectful/Labeled.hs
+++ b/effectful-core/src/Effectful/Labeled.hs
@@ -51,7 +51,8 @@ data instance StaticRep (Labeled label e)
 -- | Run a 'Labeled' effect with a given effect handler.
 runLabeled
   :: forall label e es a b
-   . (Eff (e : es) a -> Eff es b)
+   . HasCallStack
+  => (Eff (e : es) a -> Eff es b)
   -- ^ The effect handler.
   -> Eff (Labeled label e : es) a
   -> Eff es b
@@ -62,7 +63,7 @@ runLabeled runE m = runE (fromLabeled m)
 -- Useful for running code written with the non-labeled effect in mind.
 labeled
   :: forall label e es a
-   . Labeled label e :> es
+   . (HasCallStack, Labeled label e :> es)
   => Eff (e : es) a
   -- ^ The action using the effect.
   -> Eff es a

--- a/effectful-core/src/Effectful/Labeled/Error.hs
+++ b/effectful-core/src/Effectful/Labeled/Error.hs
@@ -38,7 +38,8 @@ import Effectful.Error.Dynamic qualified as E
 -- | Handle errors of type @e@ (via "Effectful.Error.Static").
 runError
   :: forall label e es a
-   . Eff (Labeled label (Error e) : es) a
+   . HasCallStack
+  => Eff (Labeled label (Error e) : es) a
   -> Eff es (Either (E.CallStack, e) a)
 runError = runLabeled @label E.runError
 
@@ -46,7 +47,8 @@ runError = runLabeled @label E.runError
 -- error handler.
 runErrorWith
   :: forall label e es a
-  . (E.CallStack -> e -> Eff es a)
+   . HasCallStack
+  => (E.CallStack -> e -> Eff es a)
   -- ^ The error handler.
   -> Eff (Labeled label (Error e) : es) a
   -> Eff es a
@@ -56,7 +58,8 @@ runErrorWith = runLabeled @label . E.runErrorWith
 -- error discard the 'E.CallStack'.
 runErrorNoCallStack
   :: forall label e es a
-   . Eff (Labeled label (Error e) : es) a
+   . HasCallStack
+  => Eff (Labeled label (Error e) : es) a
   -> Eff es (Either e a)
 runErrorNoCallStack = runLabeled @label E.runErrorNoCallStack
 
@@ -64,7 +67,8 @@ runErrorNoCallStack = runLabeled @label E.runErrorNoCallStack
 -- error handler. In case of an error discard the 'CallStack'.
 runErrorNoCallStackWith
   :: forall label e es a
-   . (e -> Eff es a)
+   . HasCallStack
+  => (e -> Eff es a)
   -- ^ The error handler.
   -> Eff (Labeled label (Error e) : es) a
   -> Eff es a

--- a/effectful-core/src/Effectful/Labeled/Reader.hs
+++ b/effectful-core/src/Effectful/Labeled/Reader.hs
@@ -25,7 +25,8 @@ import Effectful.Reader.Dynamic qualified as R
 -- "Effectful.Reader.Static").
 runReader
   :: forall label r es a
-   . r
+   . HasCallStack
+  => r
   -- ^ The initial environment.
   -> Eff (Labeled label (Reader r) : es) a
   -> Eff es a

--- a/effectful-core/src/Effectful/Labeled/State.hs
+++ b/effectful-core/src/Effectful/Labeled/State.hs
@@ -41,7 +41,8 @@ import Effectful.State.Dynamic qualified as S
 -- value along with the final state (via "Effectful.State.Static.Local").
 runStateLocal
   :: forall label s es a
-   . s
+   . HasCallStack
+  => s
    -- ^ The initial state.
   -> Eff (Labeled label (State s) : es) a
   -> Eff es (a, s)
@@ -51,7 +52,8 @@ runStateLocal = runLabeled @label . S.runStateLocal
 -- value, discarding the final state (via "Effectful.State.Static.Local").
 evalStateLocal
   :: forall label s es a
-   . s
+   . HasCallStack
+  => s
    -- ^ The initial state.
   -> Eff (Labeled label (State s) : es) a
   -> Eff es a
@@ -61,7 +63,8 @@ evalStateLocal = runLabeled @label . S.evalStateLocal
 -- state, discarding the final value (via "Effectful.State.Static.Local").
 execStateLocal
   :: forall label s es a
-   . s
+   . HasCallStack
+  => s
    -- ^ The initial state.
   -> Eff (Labeled label (State s) : es) a
   -> Eff es s
@@ -74,7 +77,8 @@ execStateLocal = runLabeled @label . S.execStateLocal
 -- value along with the final state (via "Effectful.State.Static.Shared").
 runStateShared
   :: forall label s es a
-   . s
+   . HasCallStack
+  => s
    -- ^ The initial state.
   -> Eff (Labeled label (State s) : es) a
   -> Eff es (a, s)
@@ -84,7 +88,8 @@ runStateShared = runLabeled @label . S.runStateShared
 -- value, discarding the final state (via "Effectful.State.Static.Shared").
 evalStateShared
   :: forall label s es a
-   . s
+   . HasCallStack
+  => s
    -- ^ The initial state.
   -> Eff (Labeled label (State s) : es) a
   -> Eff es a
@@ -94,7 +99,8 @@ evalStateShared = runLabeled @label . S.evalStateShared
 -- state, discarding the final value (via "Effectful.State.Static.Shared").
 execStateShared
   :: forall label s es a
-   . s
+   . HasCallStack
+  => s
    -- ^ The initial state.
   -> Eff (Labeled label (State s) : es) a
   -> Eff es s

--- a/effectful-core/src/Effectful/Labeled/Writer.hs
+++ b/effectful-core/src/Effectful/Labeled/Writer.hs
@@ -35,7 +35,7 @@ import Effectful.Writer.Dynamic qualified as W
 -- output (via "Effectful.Writer.Static.Local").
 runWriterLocal
   :: forall label w es a
-   . Monoid w
+   . (HasCallStack, Monoid w)
   => Eff (Labeled label (Writer w) : es)
   a -> Eff es (a, w)
 runWriterLocal = runLabeled @label W.runWriterLocal
@@ -44,7 +44,7 @@ runWriterLocal = runLabeled @label W.runWriterLocal
 -- value (via "Effectful.Writer.Static.Local").
 execWriterLocal
   :: forall label w es a
-   . Monoid w
+   . (HasCallStack, Monoid w)
   => Eff (Labeled label (Writer w) : es) a
   -> Eff es w
 execWriterLocal = runLabeled @label W.execWriterLocal
@@ -56,7 +56,7 @@ execWriterLocal = runLabeled @label W.execWriterLocal
 -- output (via "Effectful.Writer.Static.Shared").
 runWriterShared
   :: forall label w es a
-   . Monoid w
+   . (HasCallStack, Monoid w)
   => Eff (Labeled label (Writer w) : es) a
   -> Eff es (a, w)
 runWriterShared = runLabeled @label W.runWriterShared
@@ -65,7 +65,7 @@ runWriterShared = runLabeled @label W.runWriterShared
 -- value (via "Effectful.Writer.Static.Shared").
 execWriterShared
   :: forall label w es a
-   . Monoid w
+   . (HasCallStack, Monoid w)
   => Eff (Labeled label (Writer w) : es) a
   -> Eff es w
 execWriterShared = runLabeled @label W.execWriterShared

--- a/effectful-core/src/Effectful/NonDet.hs
+++ b/effectful-core/src/Effectful/NonDet.hs
@@ -50,12 +50,19 @@ data OnEmptyPolicy
 -- computation calls 'Empty'.
 --
 -- @since 2.2.0.0
-runNonDet :: OnEmptyPolicy -> Eff (NonDet : es) a -> Eff es (Either CallStack a)
+runNonDet
+  :: HasCallStack
+  => OnEmptyPolicy
+  -> Eff (NonDet : es) a
+  -> Eff es (Either CallStack a)
 runNonDet = \case
   OnEmptyKeep     -> runNonDetKeep
   OnEmptyRollback -> runNonDetRollback
 
-runNonDetKeep :: Eff (NonDet : es) a -> Eff es (Either CallStack a)
+runNonDetKeep
+  :: HasCallStack
+  => Eff (NonDet : es) a
+  -> Eff es (Either CallStack a)
 runNonDetKeep = reinterpret (fmap noError . runError @()) $ \env -> \case
   Empty       -> throwError ()
   m1 :<|>: m2 -> localSeqUnlift env $ \unlift -> do
@@ -64,7 +71,10 @@ runNonDetKeep = reinterpret (fmap noError . runError @()) $ \env -> \case
       Just r  -> pure r
       Nothing -> unlift m2
 
-runNonDetRollback :: Eff (NonDet : es) a -> Eff es (Either CallStack a)
+runNonDetRollback
+  :: HasCallStack
+  => Eff (NonDet : es) a
+  -> Eff es (Either CallStack a)
 runNonDetRollback = reinterpret (fmap noError . runError @()) $ \env -> \case
   Empty       -> throwError ()
   m1 :<|>: m2 -> do

--- a/effectful-core/src/Effectful/Provider/List.hs
+++ b/effectful-core/src/Effectful/Provider/List.hs
@@ -57,7 +57,7 @@ data instance StaticRep (ProviderList effs input f) where
 
 -- | Run the 'ProviderList' effect with a given handler.
 runProviderList
-  :: KnownEffects effs
+  :: (HasCallStack, KnownEffects effs)
   => (forall r. input -> Eff (effs ++ es) r -> Eff es (f r))
   -- ^ The handler.
   -> Eff (ProviderList effs input f : es) a
@@ -71,7 +71,7 @@ runProviderList run m = unsafeEff $ \es0 -> do
 -- | Run the 'Provider' effect with a given handler that doesn't change its
 -- return type.
 runProviderList_
-  :: KnownEffects effs
+  :: (HasCallStack, KnownEffects effs)
   => (forall r. input -> Eff (effs ++ es) r -> Eff es r)
   -- ^ The handler.
   -> Eff (ProviderList_ effs input : es) a
@@ -81,7 +81,7 @@ runProviderList_ run = runProviderList $ \input -> coerce . run input
 -- | Run the handler.
 provideList
   :: forall effs f es a
-   . ProviderList effs () f :> es
+   . (HasCallStack, ProviderList effs () f :> es)
   => Eff (effs ++ es) a
   -> Eff es (f a)
 provideList = provideListWith @effs ()
@@ -89,7 +89,7 @@ provideList = provideListWith @effs ()
 -- | Run the handler with unchanged return type.
 provideList_
   :: forall effs es a
-   . ProviderList_ effs () :> es
+   . (HasCallStack, ProviderList_ effs () :> es)
   => Eff (effs ++ es) a
   -> Eff es a
 provideList_ = provideListWith_ @effs ()
@@ -97,7 +97,7 @@ provideList_ = provideListWith_ @effs ()
 -- | Run the handler with a given input.
 provideListWith
   :: forall effs input f es a
-   . ProviderList effs input f :> es
+   . (HasCallStack, ProviderList effs input f :> es)
   => input
   -- ^ The input to the handler.
   -> Eff (effs ++ es) a
@@ -110,7 +110,7 @@ provideListWith input action = unsafeEff $ \es -> do
 -- | Run the handler that doesn't change its return type with a given input.
 provideListWith_
   :: forall effs input es a
-   . ProviderList_ effs input :> es
+   . (HasCallStack, ProviderList_ effs input :> es)
   => input
   -- ^ The input to the handler.
   -> Eff (effs ++ es) a
@@ -130,7 +130,7 @@ relinkProviderList = Relinker $ \relink (ProviderList handlerEs run) -> do
 
 copyRefs
   :: forall effs handlerEs es
-   . KnownEffects effs
+   . (HasCallStack, KnownEffects effs)
   => Env (effs ++ handlerEs)
   -> Env es
   -> IO (Env (effs ++ es))

--- a/effectful-core/src/Effectful/Reader/Dynamic.hs
+++ b/effectful-core/src/Effectful/Reader/Dynamic.hs
@@ -30,7 +30,8 @@ type instance DispatchOf (Reader r) = Dynamic
 -- | Run the 'Reader' effect with the given initial environment (via
 -- "Effectful.Reader.Static").
 runReader
-  :: r -- ^ The initial environment.
+  :: HasCallStack
+  => r -- ^ The initial environment.
   -> Eff (Reader r : es) a
   -> Eff es a
 runReader r = reinterpret (R.runReader r) $ \env -> \case
@@ -41,7 +42,8 @@ runReader r = reinterpret (R.runReader r) $ \env -> \case
 --
 -- @since 1.1.0.0
 withReader
-  :: (r1 -> r2)
+  :: HasCallStack
+  => (r1 -> r2)
   -- ^ The function to modify the environment.
   -> Eff (Reader r2 : es) a
   -- ^ Computation to run in the modified environment.

--- a/effectful-core/src/Effectful/Reader/Static.hs
+++ b/effectful-core/src/Effectful/Reader/Static.hs
@@ -27,7 +27,8 @@ newtype instance StaticRep (Reader r) = Reader r
 
 -- | Run a 'Reader' effect with the given initial environment.
 runReader
-  :: r -- ^ The initial environment.
+  :: HasCallStack
+  => r -- ^ The initial environment.
   -> Eff (Reader r : es) a
   -> Eff es a
 runReader r = evalStaticRep (Reader r)
@@ -36,7 +37,8 @@ runReader r = evalStaticRep (Reader r)
 --
 -- @since 1.1.0.0
 withReader
-  :: (r1 -> r2)
+  :: HasCallStack
+  => (r1 -> r2)
   -- ^ The function to modify the environment.
   -> Eff (Reader r2 : es) a
   -- ^ Computation to run in the modified environment.
@@ -46,7 +48,7 @@ withReader f m = do
   raise $ runReader (f r) m
 
 -- | Fetch the value of the environment.
-ask :: Reader r :> es => Eff es r
+ask :: (HasCallStack, Reader r :> es) => Eff es r
 ask = do
   Reader r <- getStaticRep
   pure r
@@ -55,7 +57,7 @@ ask = do
 --
 -- @'asks' f ≡ f '<$>' 'ask'@
 asks
-  :: Reader r :> es
+  :: (HasCallStack, Reader r :> es)
   => (r -> a) -- ^ The function to apply to the environment.
   -> Eff es a
 asks f = f <$> ask
@@ -65,7 +67,7 @@ asks f = f <$> ask
 -- @'runReader' r ('local' f m) ≡ 'runReader' (f r) m@
 --
 local
-  :: Reader r :> es
+  :: (HasCallStack, Reader r :> es)
   => (r -> r) -- ^ The function to modify the environment.
   -> Eff es a
   -> Eff es a

--- a/effectful-core/src/Effectful/State/Dynamic.hs
+++ b/effectful-core/src/Effectful/State/Dynamic.hs
@@ -48,24 +48,20 @@ type instance DispatchOf (State s) = Dynamic
 
 -- | Run the 'State' effect with the given initial state and return the final
 -- value along with the final state (via "Effectful.State.Static.Local").
-runStateLocal :: s -> Eff (State s : es) a -> Eff es (a, s)
+runStateLocal :: HasCallStack => s -> Eff (State s : es) a -> Eff es (a, s)
 runStateLocal s0 = reinterpret (L.runState s0) localState
 
 -- | Run the 'State' effect with the given initial state and return the final
 -- value, discarding the final state (via "Effectful.State.Static.Local").
-evalStateLocal :: s -> Eff (State s : es) a -> Eff es a
+evalStateLocal :: HasCallStack => s -> Eff (State s : es) a -> Eff es a
 evalStateLocal s0 = reinterpret (L.evalState s0) localState
 
 -- | Run the 'State' effect with the given initial state and return the final
 -- state, discarding the final value (via "Effectful.State.Static.Local").
-execStateLocal :: s -> Eff (State s : es) a -> Eff es s
+execStateLocal :: HasCallStack => s -> Eff (State s : es) a -> Eff es s
 execStateLocal s0 = reinterpret (L.execState s0) localState
 
-localState
-  :: L.State s :> es
-  => LocalEnv localEs es
-  -> State s (Eff localEs) a
-  -> Eff es a
+localState :: L.State s :> es => EffectHandler (State s) es
 localState env = \case
   Get      -> L.get
   Put s    -> L.put s
@@ -77,24 +73,20 @@ localState env = \case
 
 -- | Run the 'State' effect with the given initial state and return the final
 -- value along with the final state (via "Effectful.State.Static.Shared").
-runStateShared :: s -> Eff (State s : es) a -> Eff es (a, s)
+runStateShared :: HasCallStack => s -> Eff (State s : es) a -> Eff es (a, s)
 runStateShared s0 = reinterpret (S.runState s0) sharedState
 
 -- | Run the 'State' effect with the given initial state and return the final
 -- value, discarding the final state (via "Effectful.State.Static.Shared").
-evalStateShared :: s -> Eff (State s : es) a -> Eff es a
+evalStateShared :: HasCallStack => s -> Eff (State s : es) a -> Eff es a
 evalStateShared s0 = reinterpret (S.evalState s0) sharedState
 
 -- | Run the 'State' effect with the given initial state and return the final
 -- state, discarding the final value (via "Effectful.State.Static.Shared").
-execStateShared :: s -> Eff (State s : es) a -> Eff es s
+execStateShared :: HasCallStack => s -> Eff (State s : es) a -> Eff es s
 execStateShared s0 = reinterpret (S.execState s0) sharedState
 
-sharedState
-  :: S.State s :> es
-  => LocalEnv localEs es
-  -> State s (Eff localEs) a
-  -> Eff es a
+sharedState :: S.State s :> es => EffectHandler (State s) es
 sharedState env = \case
   Get      -> S.get
   Put s    -> S.put s

--- a/effectful-core/src/Effectful/Writer/Dynamic.hs
+++ b/effectful-core/src/Effectful/Writer/Dynamic.hs
@@ -40,19 +40,15 @@ type instance DispatchOf (Writer w) = Dynamic
 
 -- | Run the 'Writer' effect and return the final value along with the final
 -- output (via "Effectful.Writer.Static.Local").
-runWriterLocal :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
+runWriterLocal :: (HasCallStack, Monoid w) => Eff (Writer w : es) a -> Eff es (a, w)
 runWriterLocal = reinterpret L.runWriter localWriter
 
 -- | Run a 'Writer' effect and return the final output, discarding the final
 -- value (via "Effectful.Writer.Static.Local").
-execWriterLocal :: Monoid w => Eff (Writer w : es) a -> Eff es w
+execWriterLocal :: (HasCallStack, Monoid w) => Eff (Writer w : es) a -> Eff es w
 execWriterLocal = reinterpret L.execWriter localWriter
 
-localWriter
-  :: (L.Writer w :> es, Monoid w)
-  => LocalEnv localEs es
-  -> Writer w (Eff localEs) a
-  -> Eff es a
+localWriter :: (L.Writer w :> es, Monoid w) => EffectHandler (Writer w) es
 localWriter env = \case
   Tell w   -> L.tell w
   Listen m -> localSeqUnlift env $ \unlift -> L.listen (unlift m)
@@ -62,19 +58,15 @@ localWriter env = \case
 
 -- | Run the 'Writer' effect and return the final value along with the final
 -- output (via "Effectful.Writer.Static.Shared").
-runWriterShared :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
+runWriterShared :: (HasCallStack, Monoid w) => Eff (Writer w : es) a -> Eff es (a, w)
 runWriterShared = reinterpret S.runWriter sharedWriter
 
 -- | Run the 'Writer' effect and return the final output, discarding the final
 -- value (via "Effectful.Writer.Static.Shared").
-execWriterShared :: Monoid w => Eff (Writer w : es) a -> Eff es w
+execWriterShared :: (HasCallStack, Monoid w) => Eff (Writer w : es) a -> Eff es w
 execWriterShared = reinterpret S.execWriter sharedWriter
 
-sharedWriter
-  :: (S.Writer w :> es, Monoid w)
-  => LocalEnv localEs es
-  -> Writer w (Eff localEs) a
-  -> Eff es a
+sharedWriter :: (S.Writer w :> es, Monoid w) => EffectHandler (Writer w) es
 sharedWriter env = \case
   Tell w    -> S.tell w
   Listen m  -> localSeqUnlift env $ \unlift -> S.listen (unlift m)


### PR DESCRIPTION
Bechmarks are pretty much unaffected because most of these functions are small and GHC inlines them.