### PR TITLE
Distinguish between undefined effect data and its relinker

### DIFF
--- a/effectful-core/src/Effectful/Dispatch/Dynamic.hs
+++ b/effectful-core/src/Effectful/Dispatch/Dynamic.hs
@@ -1031,7 +1031,8 @@ localBorrow (LocalEnv les) strategy k = case strategy of
 {-# INLINE localBorrow #-}
 
 copyRefs
-  :: forall es srcEs destEs. KnownSubset es srcEs
+  :: forall es srcEs destEs
+   . (HasCallStack, KnownSubset es srcEs)
   => Env srcEs
   -> Env destEs
   -> IO (Env (es ++ destEs))

--- a/effectful-core/src/Effectful/Internal/Monad.hs
+++ b/effectful-core/src/Effectful/Internal/Monad.hs
@@ -279,7 +279,7 @@ type instance DispatchOf NonDet = Dynamic
 
 -- | @since 2.2.0.0
 instance NonDet :> es => Alternative (Eff es) where
-  empty   = withFrozenCallStack (send Empty)
+  empty   = send Empty
   a <|> b = send (a :<|>: b)
 
 -- | @since 2.2.0.0

--- a/effectful-core/src/Effectful/NonDet.hs
+++ b/effectful-core/src/Effectful/NonDet.hs
@@ -111,12 +111,14 @@ noError :: Either (cs, e) a -> Either cs a
 noError = either (Left . fst) Right
 
 cloneLocalEnv
-  :: LocalEnv localEs handlerEs
+  :: HasCallStack
+  => LocalEnv localEs handlerEs
   -> Eff es (LocalEnv localEs handlerEs)
 cloneLocalEnv = coerce . unsafeEff_ . cloneEnv . coerce
 
 restoreLocalEnv
-  :: LocalEnv localEs handlerEs
+  :: HasCallStack
+  => LocalEnv localEs handlerEs
   -> LocalEnv localEs handlerEs
   -> Eff es ()
 restoreLocalEnv dest src = unsafeEff_ $ restoreEnv (coerce dest) (coerce src)


### PR DESCRIPTION
Moreover, now trying to access undefinedRelinker will properly give you the call stack of where the relinker was called (i.e. in which call to cloneEnv), not where it was put into Storage (unfortunately I couldn't make it work for undefinedEffect).