### PR TITLE
Support good type inference with unique parametrized effects

### DIFF
--- a/effectful-core/effectful-core.cabal
+++ b/effectful-core/effectful-core.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 build-type:         Simple
 name:               effectful-core
-version:            2.5.0.0
+version:            2.5.1.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Control

--- a/effectful-core/src/Effectful.hs
+++ b/effectful-core/src/Effectful.hs
@@ -27,6 +27,7 @@ module Effectful
   , Dispatch(..)
   , DispatchOf
   , (:>)
+  , type (<:>)
   , (:>>)
 
     -- * Running the 'Eff' monad

--- a/effectful-core/src/Effectful/Internal/Effect.hs
+++ b/effectful-core/src/Effectful/Internal/Effect.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}
 -- | Type-safe indexing for 'Effectful.Internal.Monad.Env'.
@@ -16,7 +17,15 @@ module Effectful.Internal.Effect
   , type (++)
   , KnownEffects(..)
 
-  -- * Re-exports
+    -- * The effects
+  , type (<:>)
+  , The1
+  , The2
+  , The3
+  , The4
+  , The5
+
+    -- * Re-exports
   , Type
   ) where
 
@@ -148,3 +157,52 @@ instance KnownEffects es => KnownEffects (e : es) where
 
 instance KnownEffects '[] where
   knownEffectsLength = 0
+
+----------------------------------------
+
+type family (e :: Effect) <:> (es :: [Effect]) :: Constraint where
+  e a1 a2 a3 a4 a5 <:> es = The5 e a1 a2 a3 a4 a5 es
+  e a1 a2 a3 a4 <:> es = The4 e a1 a2 a3 a4 es
+  e a1 a2 a3 <:> es = The3 e a1 a2 a3 es
+  e a1 a2 <:> es = The2 e a1 a2 es
+  e a1 <:> es = The1 e a1 es
+
+class e a1 :> es => The1
+  (e :: k1 -> Effect)
+  (a1 :: k1)
+  (es :: [Effect])
+  | e es -> a1
+
+class e a1 a2 :> es => The2
+  (e :: k1 -> k2 -> Effect)
+  (a1 :: k1)
+  (a2 :: k2)
+  (es :: [Effect])
+  | e es -> a1 a2
+
+class e a1 a2 a3 :> es => The3
+  (e :: k1 -> k2 -> k3 -> Effect)
+  (a1 :: k1)
+  (a2 :: k2)
+  (a3 :: k3)
+  (es :: [Effect])
+  | e es -> a1 a2 a3
+
+class e a1 a2 a3 a4 :> es => The4
+  (e :: k1 -> k2 -> k3 -> k4 -> Effect)
+  (a1 :: k1)
+  (a2 :: k2)
+  (a3 :: k3)
+  (a4 :: k4)
+  (es :: [Effect])
+  | e es -> a1 a2 a3 a4
+
+class e a1 a2 a3 a4 a5 :> es => The5
+  (e :: k1 -> k2 -> k3 -> k4 -> k5 -> Effect)
+  (a1 :: k1)
+  (a2 :: k2)
+  (a3 :: k3)
+  (a4 :: k4)
+  (a5 :: k5)
+  (es :: [Effect])
+  | e es -> a1 a2 a3 a4 a5

--- a/effectful-th/effectful-th.cabal
+++ b/effectful-th/effectful-th.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 build-type:         Simple
 name:               effectful-th
-version:            1.0.0.3
+version:            1.0.1.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Control

--- a/effectful-th/tests/ThTests.hs
+++ b/effectful-th/tests/ThTests.hs
@@ -4,6 +4,7 @@
 module Main where
 
 import Data.Kind (Type)
+import Data.String
 import GHC.TypeLits
 
 import Effectful
@@ -11,6 +12,21 @@ import Effectful.TH
 
 main :: IO ()
 main = pure () -- only compilation tests
+
+data Test1 a :: Effect where
+  Test1 :: Test1 a m a
+makeTheEffect ''Test1
+
+data Test2 a b :: Effect where
+  Test2 :: Test2 a b m (a, b)
+  AmbTest :: Test2 a b m ()
+makeTheEffect ''Test2
+
+test :: (Num n, IsString s, Test1 n <:> es, Test2 s Char <:> es) => Eff es ()
+test = do
+  _ <- test1
+  _ <- test2
+  ambTest
 
 data SimpleADT (m :: Type -> Type) (a :: Type)
   = SimpleADTC1 Int

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 build-type:         Simple
 name:               effectful
-version:            2.5.0.0
+version:            2.5.1.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Control
@@ -74,7 +74,7 @@ library
                     , async               >= 2.2.2
                     , bytestring          >= 0.10
                     , directory           >= 1.3.2
-                    , effectful-core      >= 2.5.0.0   && < 2.5.1.0
+                    , effectful-core      >= 2.5.1.0   && < 2.5.2.0
                     , process             >= 1.6.9
                     , strict-mutable-base >= 1.1.0.0
                     , time                >= 1.9.2


### PR DESCRIPTION
I'm very much dissatisfied with the type inference story for parametrized effects.

It's either thousands of type applications or `effectful-plugin` and I don't particularly like the unnecessary verbosity that comes with the former and the fact that the latter is, well, a GHC plugin and GHC plugins have bugs and usually need to be adjusted for every new GHC version.

Considering the fact that if you use an effect with parameters, then in the vast majority of cases there will be only one instance of it you're using at a time, I remembered https://github.com/re-xyr/cleff/issues/23 and managed to package the idea into a nice-looking interface, so now for chosen effects you can do this:

```haskell
data Test1 a :: Effect where
  Test1 :: Test1 a m a
makeTheEffect ''Test1

data Test2 a b :: Effect where
  Test2 :: Test2 a b m (a, b)
  AmbTest :: Test2 a b m ()
makeTheEffect ''Test2

test :: (Num n, IsString s, Test1 n <:> es, Test2 s Char <:> es) => Eff es ()
test = do
  _ <- test1
  _ <- test2
  ambTest
```

(or write helper functions by hand as usual, just using `<:>` instead of `:>`) and it compiles without ambiguity errors.

This PR provides helpers for determining all type parameters up to 5, but one can write a local helper class for any combination.

Thoughts about naming? I think `TheN` helpers are fine (I thought about `UniqueN`, but I like `TheN` better). Not quite sure about `<:>`, though I couldn't come up with anything better.

TODO:
- [ ] Better naming?
- [ ] Documentation.
- [ ] Helper functions for relevant built-in effects (both static and dynamic).
