### PR TITLE
Fix a potential space leak related to HasCallStack quirks

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 * Add `passthrough` to `Effectful.Dispatch.Dynamic` for passing operations to
   the upstream handler within `interpose` and `impose` without having to fully
   pattern match on them.
+* **Bugfixes**:
+  - Fix a potential space leak related to `HasCallStack` quirks
+    (https://gitlab.haskell.org/ghc/ghc/-/issues/25520).
 
 # effectful-core-2.5.0.0 (2024-10-23)
 * Add `plusEff` (specialized version of `<|>`) to `Effectful.NonDet` and make

--- a/effectful/CHANGELOG.md
+++ b/effectful/CHANGELOG.md
@@ -2,6 +2,9 @@
 * Add `passthrough` to `Effectful.Dispatch.Dynamic` for passing operations to
   the upstream handler within `interpose` and `impose` without having to fully
   pattern match on them.
+* **Bugfixes**:
+  - Fix a potential space leak related to `HasCallStack` quirks
+    (https://gitlab.haskell.org/ghc/ghc/-/issues/25520).
 
 # effectful-2.5.0.0 (2024-10-23)
 * Add `plusEff` (specialized version of `<|>`) to `Effectful.NonDet` and make


### PR DESCRIPTION
The following program:

```haskell
import Control.Monad
import Effectful
import Effectful.Concurrent
import Effectful.Concurrent.MVar
import Effectful.Reader.Dynamic
import Effectful.Provider
import Effectful.Provider.List

f :: Concurrent :> es => MVar () -> Int -> Eff es ()
f var = \case
  0 -> putMVar var ()
  n -> void $ forkIO $ f var (n - 1)

main :: IO ()
main = runEff
  . runReader ()
  . runProvider_ (\() -> runReader ())
  . runProviderList_ @'[Reader ()] (\() -> runReader ())
  . runConcurrent $ do
  var <- newEmptyMVar
  f var 10000000
  takeMVar var
```

used to leak memory because GHC attaches a new stack frame to fields with HasCallStack constraints on every record reconstruction. Here it means every relinking, so if the relinks are nested, call stacks atached to these fields will keep growing.

The workaround is to wrap these fields in newtypes, see https://gitlab.haskell.org/ghc/ghc/-/issues/25520 for more information.