### PR TITLE
Add Input and Output effects

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -1,4 +1,12 @@
 # effectful-core-2.7.0.0 (2026-??-??)
+* Add the `Input` effect (`Effectful.Input.Dynamic`, `Effectful.Input.Static`,
+  `Effectful.Input.Static.Action` and `Effectful.Labeled.Input`) for access to
+  values.
+* Add the `Output` effect (`Effectful.Output.Dynamic`,
+  `Effectful.Output.Static.Action`, `Effectful.Output.Static.Local.Array`,
+  `Effectful.Output.Static.Local.List`, `Effectful.Output.Static.Shared.Array`,
+  `Effectful.Output.Static.Shared.List` and `Effectful.Labeled.Output`) for
+  accumulation of values.
 * Drop support for GHC < 9.6.
 * Add definitions of `rethrowM` to `MonadThrow` and `catchNoPropagate` to
   `MonadCatch` instances for `Eff` when appropriate (`exceptions` >= 0.10.11).

--- a/effectful-core/effectful-core.cabal
+++ b/effectful-core/effectful-core.cabal
@@ -90,6 +90,9 @@ library
                      Effectful.Error.Static
                      Effectful.Exception
                      Effectful.Fail
+                     Effectful.Input.Dynamic
+                     Effectful.Input.Static
+                     Effectful.Input.Static.Action
                      Effectful.Internal.Effect
                      Effectful.Internal.Effect.Dynamic
                      Effectful.Internal.Env
@@ -99,10 +102,18 @@ library
                      Effectful.Internal.Utils.Word64Map
                      Effectful.Labeled
                      Effectful.Labeled.Error
+                     Effectful.Labeled.Input
+                     Effectful.Labeled.Output
                      Effectful.Labeled.Reader
                      Effectful.Labeled.State
                      Effectful.Labeled.Writer
                      Effectful.NonDet
+                     Effectful.Output.Dynamic
+                     Effectful.Output.Static.Action
+                     Effectful.Output.Static.Local.Array
+                     Effectful.Output.Static.Local.List
+                     Effectful.Output.Static.Shared.Array
+                     Effectful.Output.Static.Shared.List
                      Effectful.Prim
                      Effectful.Provider
                      Effectful.Provider.List

--- a/effectful-core/src/Effectful/Input/Dynamic.hs
+++ b/effectful-core/src/Effectful/Input/Dynamic.hs
@@ -1,0 +1,68 @@
+-- | The dynamically dispatched variant of the 'Input' effect.
+--
+-- /Note:/ unless you plan to change interpretations at runtime, it's
+-- recommended to use one of the statically dispatched variants,
+-- i.e. "Effectful.Input.Static" or "Effectful.Input.Static.Action".
+--
+-- @since 2.7.0.0
+module Effectful.Input.Dynamic
+  ( -- * Effect
+    Input(..)
+
+    -- ** Handlers
+  , runInput
+  , runInputAction
+
+    -- ** Operations
+  , input
+  , inputs
+  ) where
+
+import Effectful
+import Effectful.Dispatch.Dynamic
+
+-- | Provide access to values of type @i@.
+data Input i :: Effect where
+  Input :: Input i m i
+
+type instance DispatchOf (Input i) = Dynamic
+
+----------------------------------------
+-- Handlers
+
+-- | Run the 'Input' effect with the given value.
+runInput
+  :: HasCallStack
+  => i
+  -- ^ The input value.
+  -> Eff (Input i : es) a
+  -> Eff es a
+runInput inputValue = interpret_ $ \case
+  Input -> pure inputValue
+
+-- | Run the 'Input' effect with the given action that supplies values.
+runInputAction
+  :: forall i es a
+   . HasCallStack
+  => (HasCallStack => Eff es i)
+  -- ^ The action for input generation.
+  -> Eff (Input i : es) a
+  -> Eff es a
+runInputAction inputAction = interpret_ $ \case
+  Input -> inputAction
+
+----------------------------------------
+-- Operations
+
+-- | Fetch the value.
+input :: (HasCallStack, Input i :> es) => Eff es i
+input = send Input
+
+-- | Fetch the result of applying a function to the value.
+--
+-- @'inputs' f ≡ f '<$>' 'input'@
+inputs
+  :: (HasCallStack, Input i :> es)
+  => (i -> a) -- ^ The function to apply to the value.
+  -> Eff es a
+inputs f = f <$> input

--- a/effectful-core/src/Effectful/Input/Static.hs
+++ b/effectful-core/src/Effectful/Input/Static.hs
@@ -1,0 +1,49 @@
+-- | Support for access to a value of a particular type.
+--
+-- @since 2.7.0.0
+module Effectful.Input.Static
+  ( -- * Effect
+    Input
+
+    -- ** Handlers
+  , runInput
+
+    -- ** Operations
+  , input
+  , inputs
+  ) where
+
+import Data.Kind
+
+import Effectful
+import Effectful.Dispatch.Static
+
+-- | Provide access to a value of type @i@.
+data Input (i :: Type) :: Effect
+
+type instance DispatchOf (Input i) = Static NoSideEffects
+newtype instance StaticRep (Input i) = Input i
+
+-- | Run the 'Input' effect with the given value.
+runInput
+  :: HasCallStack
+  => i
+  -- ^ The input value.
+  -> Eff (Input i : es) a
+  -> Eff es a
+runInput = evalStaticRep . Input
+
+-- | Fetch the value.
+input :: (HasCallStack, Input i :> es) => Eff es i
+input = do
+  Input i <- getStaticRep
+  pure i
+
+-- | Fetch the result of applying a function to the value.
+--
+-- @'inputs' f ≡ f '<$>' 'input'@
+inputs
+  :: (HasCallStack, Input i :> es)
+  => (i -> a) -- ^ The function to apply to the value.
+  -> Eff es a
+inputs f = f <$> input

--- a/effectful-core/src/Effectful/Input/Static/Action.hs
+++ b/effectful-core/src/Effectful/Input/Static/Action.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE ImplicitParams #-}
+-- | Support for access to values supplied by a monadic action.
+--
+-- @since 2.7.0.0
+module Effectful.Input.Static.Action
+  ( -- * Effect
+    Input
+
+    -- ** Handlers
+  , runInput
+
+    -- ** Operations
+  , input
+  , inputs
+  ) where
+
+import Data.Kind
+import GHC.Stack
+
+import Effectful
+import Effectful.Dispatch.Static
+import Effectful.Dispatch.Static.Primitive
+import Effectful.Internal.Utils
+
+-- | Provide access to values of type @i@ supplied by a monadic action.
+data Input (i :: Type) :: Effect
+
+type instance DispatchOf (Input i) = Static NoSideEffects
+
+-- | Wrapper to prevent a space leak on reconstruction of 'Input' in
+-- 'relinkInput' (see https://gitlab.haskell.org/ghc/ghc/-/issues/25520).
+newtype InputImpl i es where
+  InputImpl :: (HasCallStack => Eff es i) -> InputImpl i es
+
+data instance StaticRep (Input i) where
+  Input
+    :: !(Env inputEs)
+    -> !(InputImpl i inputEs)
+    -> StaticRep (Input i)
+
+-- | Run the 'Input' effect with the given action that supplies values.
+runInput
+  :: forall i es a
+   . HasCallStack
+  => (HasCallStack => Eff es i)
+  -- ^ The action for input generation.
+  -> Eff (Input i : es) a
+  -> Eff es a
+runInput inputAction action = unsafeEff $ \es -> do
+  inlineBracket
+    (consEnv (Input es inputImpl) relinkInput es)
+    unconsEnv
+    (unEff action)
+  where
+    inputImpl = InputImpl $ let ?callStack = thawCallStack ?callStack in inputAction
+
+-- | Fetch the value.
+input :: (HasCallStack, Input i :> es) => Eff es i
+input = unsafeEff $ \es -> do
+  Input inputEs (InputImpl inputAction) <- getEnv es
+  -- Corresponds to thawCallStack in runInput.
+  (`unEff` inputEs) $ withFrozenCallStack inputAction
+
+-- | Fetch the result of applying a function to the value.
+--
+-- @'inputs' f ≡ f '<$>' 'input'@
+inputs
+  :: (HasCallStack, Input i :> es)
+  => (i -> a) -- ^ The function to apply to the value.
+  -> Eff es a
+inputs f = f <$> input
+
+----------------------------------------
+-- Helpers
+
+relinkInput :: Relinker StaticRep (Input i)
+relinkInput = Relinker $ \relink (Input inputEs inputAction) -> do
+  newActionEs <- relink inputEs
+  pure $ Input newActionEs inputAction

--- a/effectful-core/src/Effectful/Labeled/Input.hs
+++ b/effectful-core/src/Effectful/Labeled/Input.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+-- | Convenience functions for the 'Labeled' 'Input' effect.
+--
+-- @since 2.7.0.0
+module Effectful.Labeled.Input
+  ( -- * Effect
+    Input
+
+    -- ** Handlers
+  , runInput
+  , runInputAction
+
+    -- ** Operations
+  , input
+  , inputs
+  ) where
+
+import Effectful
+import Effectful.Dispatch.Dynamic
+import Effectful.Labeled
+import Effectful.Input.Dynamic (Input(..))
+import Effectful.Input.Dynamic qualified as I
+
+-- | Run the 'Input' effect with the given value.
+runInput
+  :: forall label i es a
+   . HasCallStack
+  => i
+  -- ^ The input value.
+  -> Eff (Labeled label (Input i) : es) a
+  -> Eff es a
+runInput = runLabeled @label . I.runInput
+
+-- | Run the 'Input' effect with the given action that supplies values.
+runInputAction
+  :: forall label i es a
+   . HasCallStack
+  => (HasCallStack => Eff es i)
+  -- ^ The action for input generation.
+  -> Eff (Labeled label (Input i) : es) a
+  -> Eff es a
+runInputAction = runLabeled @label . I.runInputAction
+
+----------------------------------------
+-- Operations
+
+-- | Fetch the value.
+input
+  :: forall label i es
+   . (HasCallStack, Labeled label (Input i) :> es)
+  => Eff es i
+input = send $ Labeled @label Input
+
+-- | Fetch the result of applying a function to the value.
+--
+-- @'inputs' f ≡ f '<$>' 'input'@
+inputs
+  :: forall label i es a
+   . (HasCallStack, Labeled label (Input i) :> es)
+  => (i -> a) -- ^ The function to apply to the value.
+  -> Eff es a
+inputs f = f <$> input @label

--- a/effectful-core/src/Effectful/Labeled/Output.hs
+++ b/effectful-core/src/Effectful/Labeled/Output.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+-- | Convenience functions for the 'Labeled' 'Output' effect.
+--
+-- @since 2.7.0.0
+module Effectful.Labeled.Output
+  ( -- * Effect
+    Output(..)
+
+    -- ** Handlers
+  , runOutputAction
+  , runOutputLocalArray
+  , runOutputLocalList
+  , runOutputSharedArray
+  , runOutputSharedList
+
+    -- ** Operations
+  , output
+
+    -- * Re-exports
+  , Array
+  ) where
+
+import Data.Primitive.Array
+
+import Effectful
+import Effectful.Dispatch.Dynamic
+import Effectful.Labeled
+import Effectful.Output.Dynamic (Output(..))
+import Effectful.Output.Dynamic qualified as O
+
+----------------------------------------
+-- Handlers
+
+-- | Run the 'Output' effect with the given action for receiving values.
+runOutputAction
+  :: forall label o es a
+   . HasCallStack
+  => (HasCallStack => o -> Eff es ())
+  -- ^ The action for output generation.
+  -> Eff (Labeled label (Output o) : es) a
+  -> Eff es a
+runOutputAction = runLabeled @label . O.runOutputAction
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated array (via "Effectful.Output.Static.Local.Array").
+runOutputLocalArray
+  :: forall label o es a
+   . HasCallStack
+  => Eff (Labeled label (Output o) : es) a
+  -> Eff es (a, Array o)
+runOutputLocalArray = runLabeled @label O.runOutputLocalArray
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated list (via "Effectful.Output.Static.Local.List").
+runOutputLocalList
+  :: forall label o es a
+   . HasCallStack
+  => Eff (Labeled label (Output o) : es) a
+  -> Eff es (a, [o])
+runOutputLocalList = runLabeled @label O.runOutputLocalList
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated array (via "Effectful.Output.Static.Shared.Array").
+runOutputSharedArray
+  :: forall label o es a
+   . HasCallStack
+  => Eff (Labeled label (Output o) : es) a
+  -> Eff es (a, Array o)
+runOutputSharedArray = runLabeled @label O.runOutputSharedArray
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated list (via "Effectful.Output.Static.Shared.List").
+runOutputSharedList
+  :: forall label o es a
+    . HasCallStack
+  => Eff (Labeled label (Output o) : es) a
+  -> Eff es (a, [o])
+runOutputSharedList = runLabeled @label O.runOutputSharedList
+
+----------------------------------------
+-- Operations
+
+-- | Feed the value to the underlying handler.
+output
+  :: forall label o es
+   . (HasCallStack, Labeled label (Output o) :> es)
+  => o
+  -> Eff es ()
+output = send . Labeled @label . Output

--- a/effectful-core/src/Effectful/Output/Dynamic.hs
+++ b/effectful-core/src/Effectful/Output/Dynamic.hs
@@ -1,0 +1,86 @@
+-- | The dynamically dispatched variant of the 'Output' effect.
+--
+-- /Note:/ unless you plan to change interpretations at runtime, it's
+-- recommended to use one of the statically dispatched variants,
+-- i.e. "Effectful.Output.Static.Action", "Effectful.Output.Static.Local.Array",
+-- "Effectful.Output.Static.Local.List", "Effectful.Output.Static.Shared.Array"
+-- or "Effectful.Output.Static.Shared.List".
+--
+-- @since 2.7.0.0
+module Effectful.Output.Dynamic
+  ( -- * Effect
+    Output(..)
+
+    -- ** Handlers
+  , runOutputAction
+  , runOutputLocalArray
+  , runOutputLocalList
+  , runOutputSharedArray
+  , runOutputSharedList
+
+    -- ** Operations
+  , output
+  ) where
+
+import Data.Primitive.Array
+
+import Effectful
+import Effectful.Dispatch.Dynamic
+import Effectful.Output.Static.Local.Array qualified as LA
+import Effectful.Output.Static.Local.List qualified as LL
+import Effectful.Output.Static.Shared.Array qualified as SA
+import Effectful.Output.Static.Shared.List qualified as SL
+
+-- | Provide the ability to feed values of type @o@ to a handler.
+data Output o :: Effect where
+  Output :: o -> Output o m ()
+
+type instance DispatchOf (Output o) = Dynamic
+
+----------------------------------------
+-- Handlers
+
+-- | Run the 'Output' effect with the given action for receiving values.
+runOutputAction
+  :: forall o es a
+   . HasCallStack
+  => (HasCallStack => o -> Eff es ())
+  -- ^ The action for output generation.
+  -> Eff (Output o : es) a
+  -> Eff es a
+runOutputAction outputAction = interpret_ $ \case
+  Output o -> outputAction $! o
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated array (via "Effectful.Output.Static.Local.Array").
+runOutputLocalArray :: HasCallStack => Eff (Output o : es) a -> Eff es (a, Array o)
+runOutputLocalArray = reinterpret_ LA.runOutput $ \case
+  Output o -> LA.output o
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated list (via "Effectful.Output.Static.Local.List").
+runOutputLocalList :: HasCallStack => Eff (Output o : es) a -> Eff es (a, [o])
+runOutputLocalList = reinterpret_ LL.runOutput $ \case
+  Output o -> LL.output o
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated array (via "Effectful.Output.Static.Shared.Array").
+runOutputSharedArray :: HasCallStack => Eff (Output o : es) a -> Eff es (a, Array o)
+runOutputSharedArray = reinterpret_ SA.runOutput $ \case
+  Output o -> SA.output o
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated list (via "Effectful.Output.Static.Shared.List").
+runOutputSharedList :: HasCallStack => Eff (Output o : es) a -> Eff es (a, [o])
+runOutputSharedList = reinterpret_ SL.runOutput $ \case
+  Output o -> SL.output o
+
+----------------------------------------
+-- Operations
+
+-- | Feed the value to the underlying handler.
+output
+  :: (HasCallStack, Output o :> es)
+  => o -- ^ The value.
+  -> Eff es ()
+output = send . Output

--- a/effectful-core/src/Effectful/Output/Static/Action.hs
+++ b/effectful-core/src/Effectful/Output/Static/Action.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE ImplicitParams #-}
+-- | Support for feeding values of a particular type to a monadic action.
+--
+-- @since 2.7.0.0
+module Effectful.Output.Static.Action
+  ( -- * Effect
+    Output
+
+    -- ** Handlers
+  , runOutput
+
+    -- ** Operations
+  , output
+  ) where
+
+import Data.Kind
+import GHC.Stack
+
+import Effectful
+import Effectful.Dispatch.Static
+import Effectful.Dispatch.Static.Primitive
+import Effectful.Internal.Utils
+
+-- | Provide the ability to feed values of type @o@ to a monadic action.
+data Output (o :: Type) :: Effect
+
+type instance DispatchOf (Output o) = Static NoSideEffects
+
+-- | Wrapper to prevent a space leak on reconstruction of 'Output' in
+-- 'relinkOutput' (see https://gitlab.haskell.org/ghc/ghc/-/issues/25520).
+newtype OutputImpl o es where
+  OutputImpl :: (HasCallStack => o -> Eff es ()) -> OutputImpl o es
+
+data instance StaticRep (Output o) where
+  Output
+    :: !(Env actionEs)
+    -> !(OutputImpl o actionEs)
+    -> StaticRep (Output o)
+
+-- | Run the 'Output' effect with the given action for receiving values.
+runOutput
+  :: forall o es a
+   . HasCallStack
+  => (HasCallStack => o -> Eff es ())
+  -- ^ The action for receiving values.
+  -> Eff (Output o : es) a
+  -> Eff es a
+runOutput outputAction action = unsafeEff $ \es -> do
+  inlineBracket
+    (consEnv (Output es outputImpl) relinkOutput es)
+    unconsEnv
+    (unEff action)
+  where
+    outputImpl = OutputImpl $ let ?callStack = thawCallStack ?callStack in outputAction
+
+-- | Feed the value to the underlying monadic action.
+output
+  :: (HasCallStack, Output o :> es)
+  => o -- ^ The value.
+  -> Eff es ()
+output !o = unsafeEff $ \es -> do
+  Output actionEs (OutputImpl outputAction) <- getEnv es
+  -- Corresponds to thawCallStack in runOutput.
+  (`unEff` actionEs) $ withFrozenCallStack outputAction o
+
+----------------------------------------
+-- Helpers
+
+relinkOutput :: Relinker StaticRep (Output o)
+relinkOutput = Relinker $ \relink (Output actionEs outputAction) -> do
+  newActionEs <- relink actionEs
+  pure $ Output newActionEs outputAction

--- a/effectful-core/src/Effectful/Output/Static/Local/Array.hs
+++ b/effectful-core/src/Effectful/Output/Static/Local/Array.hs
@@ -1,0 +1,79 @@
+-- | Support for accumulation of values in a thread local array.
+--
+-- @since 2.7.0.0
+module Effectful.Output.Static.Local.Array
+  ( -- * Effect
+    Output
+
+    -- ** Handlers
+  , runOutput
+
+    -- ** Operations
+  , output
+
+    -- * Re-exports
+  , Array
+  ) where
+
+import Control.Monad.Primitive
+import Data.Kind
+import Data.Primitive.Array
+
+import Effectful
+import Effectful.Dispatch.Static
+import Effectful.Dispatch.Static.Primitive
+import Effectful.Internal.Utils
+
+-- | Provide access to accumulation of values of type @o@ in a thread local
+-- array.
+data Output (o :: Type) :: Effect
+
+type instance DispatchOf (Output o) = Static NoSideEffects
+data instance StaticRep (Output o) = Output !Int !(MutableArray RealWorld o)
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated array.
+runOutput :: HasCallStack => Eff (Output o : es) a -> Eff es (a, Array o)
+runOutput = runOutputImpl $ \(Output size arr) -> do
+  freezeArray arr 0 size
+
+-- | Append the value to the end of the array.
+output
+  :: (HasCallStack, Output o :> es)
+  => o -- ^ The value.
+  -> Eff es ()
+output !o = unsafeEff $ \es -> do
+  Output size arr0 <- getEnv es
+  let len0 = sizeofMutableArray arr0
+  arr <- case size `compare` len0 of
+    GT -> error $ "size (" ++ show size ++ ") > len0 (" ++ show len0 ++ ")"
+    LT -> pure arr0
+    EQ -> do
+      let len = growCapacity len0
+      arr <- newArray len undefinedValue
+      copyMutableArray arr 0 arr0 0 size
+      pure arr
+  writeArray arr size o
+  putEnv es $ Output (size + 1) arr
+
+----------------------------------------
+-- Helpers
+
+runOutputImpl
+  :: HasCallStack
+  => (StaticRep (Output o) -> IO acc)
+  -> Eff (Output o : es) a
+  -> Eff es (a, acc)
+runOutputImpl f action = unsafeEff $ \es0 -> do
+  arr <- newArray 0 undefinedValue
+  inlineBracket
+    (consEnv (Output 0 arr) relinkOutput es0)
+    unconsEnv
+    (\es -> (,) <$> unEff action es <*> (f =<< getEnv es))
+  where
+    relinkOutput = Relinker $ \_ (Output size arr0) -> do
+      arr <- cloneMutableArray arr0 0 (sizeofMutableArray arr0)
+      pure $ Output size arr
+
+undefinedValue :: HasCallStack => a
+undefinedValue = error "Undefined value"

--- a/effectful-core/src/Effectful/Output/Static/Local/List.hs
+++ b/effectful-core/src/Effectful/Output/Static/Local/List.hs
@@ -1,0 +1,39 @@
+-- | Support for accumulation of values in a thread local list.
+--
+-- @since 2.7.0.0
+module Effectful.Output.Static.Local.List
+  ( -- * Effect
+    Output
+
+    -- ** Handlers
+  , runOutput
+
+    -- ** Operations
+  , output
+  ) where
+
+import Data.Kind
+
+import Effectful
+import Effectful.Dispatch.Static
+
+-- | Provide access to accumulation of values of type @o@ in a thread local
+-- list.
+data Output (o :: Type) :: Effect
+
+type instance DispatchOf (Output o) = Static NoSideEffects
+newtype instance StaticRep (Output o) = Output [o]
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated list.
+runOutput :: HasCallStack => Eff (Output o : es) a -> Eff es (a, [o])
+runOutput action = do
+  (a, Output acc) <- runStaticRep (Output []) action
+  pure (a, reverse acc)
+
+-- | Append the value to the end of the list.
+output
+  :: (HasCallStack, Output o :> es)
+  => o -- ^ The value.
+  -> Eff es ()
+output !o = stateStaticRep $ \(Output acc) -> ((), Output (o : acc))

--- a/effectful-core/src/Effectful/Output/Static/Shared/Array.hs
+++ b/effectful-core/src/Effectful/Output/Static/Shared/Array.hs
@@ -1,0 +1,77 @@
+-- | Support for accumulation of values in a shared array.
+--
+-- @since 2.7.0.0
+module Effectful.Output.Static.Shared.Array
+  ( -- * Effect
+    Output
+
+    -- ** Handlers
+  , runOutput
+
+    -- ** Operations
+  , output
+
+    -- * Re-exports
+  , Array
+  ) where
+
+import Control.Concurrent.MVar.Strict
+import Control.Monad.Primitive
+import Data.Kind
+import Data.Primitive.Array
+
+import Effectful
+import Effectful.Dispatch.Static
+import Effectful.Dispatch.Static.Primitive
+import Effectful.Internal.Utils
+
+-- | Provide access to accumulation of values of type @o@ in a shared array.
+data Output (o :: Type) :: Effect
+
+data OutputData o = OutputData !Int !(MutableArray RealWorld o)
+
+type instance DispatchOf (Output o) = Static NoSideEffects
+newtype instance StaticRep (Output o) = Output (MVar' (OutputData o))
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated array.
+runOutput :: HasCallStack => Eff (Output o : es) a -> Eff es (a, Array o)
+runOutput = runOutputImpl $ \(OutputData size arr) -> do
+  freezeArray arr 0 size
+
+-- | Append the value to the end of the array.
+output
+  :: (HasCallStack, Output o :> es)
+  => o -- ^ The value.
+  -> Eff es ()
+output !o = unsafeEff $ \es -> do
+  Output v <- getEnv es
+  modifyMVar'_ v $ \(OutputData size arr0) -> do
+    let len0 = sizeofMutableArray arr0
+    arr <- case size `compare` len0 of
+      GT -> error $ "size (" ++ show size ++ ") > len0 (" ++ show len0 ++ ")"
+      LT -> pure arr0
+      EQ -> do
+        let len = growCapacity len0
+        arr <- newArray len undefinedValue
+        copyMutableArray arr 0 arr0 0 size
+        pure arr
+    writeArray arr size o
+    pure $ OutputData (size + 1) arr
+
+----------------------------------------
+-- Helpers
+
+runOutputImpl
+  :: HasCallStack
+  => (OutputData o -> IO acc)
+  -> Eff (Output o : es) a
+  -> Eff es (a, acc)
+runOutputImpl f action = do
+  v <- unsafeEff_ $ newMVar' . OutputData 0 =<< newArray 0 undefinedValue
+  a <- evalStaticRep (Output v) action
+  acc <- unsafeEff_ $ f =<< readMVar' v
+  pure (a, acc)
+
+undefinedValue :: HasCallStack => a
+undefinedValue = error "Undefined value"

--- a/effectful-core/src/Effectful/Output/Static/Shared/List.hs
+++ b/effectful-core/src/Effectful/Output/Static/Shared/List.hs
@@ -1,0 +1,43 @@
+-- | Support for accumulation of values in a shared list.
+--
+-- @since 2.7.0.0
+module Effectful.Output.Static.Shared.List
+  ( -- * Effect
+    Output
+
+    -- ** Handlers
+  , runOutput
+
+    -- ** Operations
+  , output
+  ) where
+
+import Control.Concurrent.MVar.Strict
+import Data.Kind
+
+import Effectful
+import Effectful.Dispatch.Static
+import Effectful.Dispatch.Static.Primitive
+
+-- | Provide access to accumulation of values of type @o@ in a shared list.
+data Output (o :: Type) :: Effect
+
+type instance DispatchOf (Output o) = Static NoSideEffects
+newtype instance StaticRep (Output o) = Output (MVar' [o])
+
+-- | Run the 'Output' effect and return the final value along with the
+-- accumulated list.
+runOutput :: HasCallStack => Eff (Output o : es) a -> Eff es (a, [o])
+runOutput action = do
+  v <- unsafeEff_ $ newMVar' []
+  a <- evalStaticRep (Output v) action
+  (a, ) . reverse <$> unsafeEff_ (readMVar' v)
+
+-- | Append the value to the end of the list.
+output
+  :: (HasCallStack, Output o :> es)
+  => o -- ^ The value.
+  -> Eff es ()
+output !o = unsafeEff $ \es -> do
+  Output v <- getEnv es
+  modifyMVar'_ v $ \acc -> pure (o : acc)

--- a/effectful-core/src/Effectful/Reader/Static.hs
+++ b/effectful-core/src/Effectful/Reader/Static.hs
@@ -1,4 +1,8 @@
 -- | Support for access to a read only value of a particular type.
+--
+-- /Note:/ strictly speaking the value is not read only because of 'local'. If
+-- you want to ensure that the initial value never changes, use
+-- "Effectful.Input.Static".
 module Effectful.Reader.Static
   ( -- * Effect
     Reader

--- a/effectful-core/src/Effectful/Writer/Dynamic.hs
+++ b/effectful-core/src/Effectful/Writer/Dynamic.hs
@@ -5,6 +5,8 @@
 -- t'Control.Monad.Writer.MonadWriter' instance for compatibility with existing
 -- code, it's recommended to use one of the statically dispatched variants,
 -- i.e. "Effectful.Writer.Static.Local" or "Effectful.Writer.Static.Shared".
+--
+-- __If you just want to accumulate values, use "Effectful.Output.Dynamic".__
 module Effectful.Writer.Dynamic
   ( -- * Effect
     Writer(..)

--- a/effectful-core/src/Effectful/Writer/Static/Local.hs
+++ b/effectful-core/src/Effectful/Writer/Static/Local.hs
@@ -8,6 +8,8 @@
 -- is inefficient. __This applies, in particular, to the standard list type__,
 -- which makes the 'Writer' effect pretty niche.
 --
+-- __If you just want to accumulate values, use "Effectful.Output.Static.Local.Array" or "Effectful.Output.Static.Local.List".__
+--
 -- /Note:/ while the 'Control.Monad.Trans.Writer.Strict.Writer' from the
 -- @transformers@ package includes additional operations
 -- 'Control.Monad.Trans.Writer.Strict.pass' and

--- a/effectful-core/src/Effectful/Writer/Static/Shared.hs
+++ b/effectful-core/src/Effectful/Writer/Static/Shared.hs
@@ -8,6 +8,8 @@
 -- is inefficient. __This applies, in particular, to the standard list type__,
 -- which makes the 'Writer' effect pretty niche.
 --
+-- __If you just want to accumulate values, use "Effectful.Output.Static.Shared.Array" or "Effectful.Output.Static.Shared.List".__
+--
 -- /Note:/ while the 'Control.Monad.Trans.Writer.Strict.Writer' from the
 -- @transformers@ package includes additional operations
 -- 'Control.Monad.Trans.Writer.Strict.pass' and
@@ -61,7 +63,7 @@ execWriter m = do
 tell :: (HasCallStack, Writer w :> es, Monoid w) => w -> Eff es ()
 tell w1 = unsafeEff $ \es -> do
   Writer v <- getEnv es
-  modifyMVar'_ v $ \w0 -> let w = w0 <> w1 in pure w
+  modifyMVar'_ v $ \w0 -> pure (w0 <> w1)
 
 -- | Execute an action and append its output to the overall output of the
 -- 'Writer'.
@@ -119,7 +121,7 @@ listen m = unsafeEff $ \es -> do
     merge es v0 v1 = do
       putEnv es $ Writer v0
       w1 <- readMVar' v1
-      modifyMVar'_ v0 $ \w0 -> let w = w0 <> w1 in pure w
+      modifyMVar'_ v0 $ \w0 -> pure (w0 <> w1)
       pure w1
 
 -- | Execute an action and append its output to the overall output of the

--- a/effectful/CHANGELOG.md
+++ b/effectful/CHANGELOG.md
@@ -1,4 +1,12 @@
 # effectful-2.7.0.0 (2026-??-??)
+* Add the `Input` effect (`Effectful.Input.Dynamic`, `Effectful.Input.Static`,
+  `Effectful.Input.Static.Action` and `Effectful.Labeled.Input`) for access to
+  values.
+* Add the `Output` effect (`Effectful.Output.Dynamic`,
+  `Effectful.Output.Static.Action`, `Effectful.Output.Static.Local.Array`,
+  `Effectful.Output.Static.Local.List`, `Effectful.Output.Static.Shared.Array`,
+  `Effectful.Output.Static.Shared.List` and `Effectful.Labeled.Output`) for
+  accumulation of values.
 * Drop support for GHC < 9.6.
 * Add definitions of `rethrowM` to `MonadThrow` and `catchNoPropagate` to
  `MonadCatch` instances for `Eff` when appropriate (`exceptions` >= 0.10.11).

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -117,16 +117,27 @@ library
     reexported-modules:    Effectful
                          , Effectful.Dispatch.Dynamic
                          , Effectful.Dispatch.Static
-                         , Effectful.Error.Static
                          , Effectful.Error.Dynamic
+                         , Effectful.Error.Static
                          , Effectful.Exception
                          , Effectful.Fail
+                         , Effectful.Input.Dynamic
+                         , Effectful.Input.Static
+                         , Effectful.Input.Static.Action
                          , Effectful.Labeled
                          , Effectful.Labeled.Error
+                         , Effectful.Labeled.Input
+                         , Effectful.Labeled.Output
                          , Effectful.Labeled.Reader
                          , Effectful.Labeled.State
                          , Effectful.Labeled.Writer
                          , Effectful.NonDet
+                         , Effectful.Output.Dynamic
+                         , Effectful.Output.Static.Action
+                         , Effectful.Output.Static.Local.Array
+                         , Effectful.Output.Static.Local.List
+                         , Effectful.Output.Static.Shared.Array
+                         , Effectful.Output.Static.Shared.List
                          , Effectful.Prim
                          , Effectful.Provider
                          , Effectful.Provider.List
@@ -171,8 +182,10 @@ test-suite test
                     EnvTests
                     EnvironmentTests
                     ErrorTests
+                    InputTests
                     LabeledTests
                     NonDetTests
+                    OutputTests
                     PrimTests
                     ReaderTests
                     StateTests

--- a/effectful/tests/InputTests.hs
+++ b/effectful/tests/InputTests.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+module InputTests (inputTests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Effectful
+import Effectful.State.Static.Local
+import Effectful.Input.Dynamic qualified as ID
+import Effectful.Input.Static qualified as IS
+import Effectful.Input.Static.Action qualified as IA
+import Effectful.Labeled.Input qualified as LI
+import Utils qualified as U
+
+inputTests :: TestTree
+inputTests = testGroup "Input"
+  [ testCase "static" test_static
+  , testCase "static action reruns the action" test_staticAction
+  , testCase "dynamic (value)" test_dynamicValue
+  , testCase "dynamic (action) reruns the action" test_dynamicAction
+  , testCase "labeled inputs are independent" test_labeled
+  ]
+
+test_static :: Assertion
+test_static = runEff . IS.runInput @Int 42 $ do
+  U.assertEqual "input" 42 =<< IS.input @Int
+  U.assertEqual "inputs" 43 =<< IS.inputs @Int (+ 1)
+
+test_staticAction :: Assertion
+test_staticAction = runEff . evalState @Int 0 . IA.runInput nextValue $ do
+  U.assertEqual "1st input" 1 =<< IA.input @Int
+  U.assertEqual "2nd input" 2 =<< IA.input @Int
+  U.assertEqual "inputs" 3 =<< IA.inputs @Int id
+
+test_dynamicValue :: Assertion
+test_dynamicValue = runEff . ID.runInput @Int 42 $ do
+  U.assertEqual "input" 42 =<< ID.input @Int
+  U.assertEqual "inputs" 43 =<< ID.inputs @Int (+ 1)
+
+test_dynamicAction :: Assertion
+test_dynamicAction = runEff . evalState @Int 0 . ID.runInputAction nextValue $ do
+  U.assertEqual "1st input" 1 =<< ID.input @Int
+  U.assertEqual "2nd input" 2 =<< ID.input @Int
+  U.assertEqual "inputs" 3 =<< ID.inputs @Int id
+
+test_labeled :: Assertion
+test_labeled = runEff
+  . evalState @Int 0
+  . LI.runInput @"a" @Int 1
+  . LI.runInputAction @"b" nextValue
+  $ do
+    U.assertEqual "a" 1 =<< LI.input @"a" @Int
+    U.assertEqual "inputs a" 11 =<< LI.inputs @"a" @Int (+ 10)
+    U.assertEqual "1st b" 1 =<< LI.input @"b" @Int
+    U.assertEqual "2nd b" 2 =<< LI.input @"b" @Int
+    -- "a" is unaffected by reads of "b".
+    U.assertEqual "a again" 1 =<< LI.input @"a" @Int
+
+-- | An action that returns consecutive integers, so that re-running it is
+-- observable.
+nextValue :: State Int :> es => Eff es Int
+nextValue = do
+  modify @Int (+ 1)
+  get

--- a/effectful/tests/Main.hs
+++ b/effectful/tests/Main.hs
@@ -7,8 +7,10 @@ import ConcurrencyTests
 import EnvTests
 import EnvironmentTests
 import ErrorTests
+import InputTests
 import LabeledTests
 import NonDetTests
+import OutputTests
 import PrimTests
 import ReaderTests
 import StateTests
@@ -23,8 +25,10 @@ main = defaultMain $ testGroup "effectful"
   , envTests
   , environmentTests
   , errorTests
+  , inputTests
   , labeledTests
   , nonDetTests
+  , outputTests
   , primTests
   , readerTests
   , stateTests

--- a/effectful/tests/OutputTests.hs
+++ b/effectful/tests/OutputTests.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+module OutputTests (outputTests) where
+
+import Data.Foldable qualified as F
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Effectful
+import Effectful.State.Static.Local
+import Effectful.Output.Dynamic qualified as OD
+import Effectful.Output.Static.Action qualified as OA
+import Effectful.Output.Static.Local.Array qualified as OLA
+import Effectful.Output.Static.Local.List qualified as OLL
+import Effectful.Output.Static.Shared.Array qualified as OSA
+import Effectful.Output.Static.Shared.List qualified as OSL
+import Effectful.Labeled.Output qualified as LO
+import Utils qualified as U
+
+outputTests :: TestTree
+outputTests = testGroup "Output"
+  [ testCase "static local list" test_localList
+  , testCase "static local array" test_localArray
+  , testCase "static shared list" test_sharedList
+  , testCase "static shared array" test_sharedArray
+  , testCase "static action" test_action
+  , testCase "dynamic dispatches to all backends" test_dynamic
+  , testCase "labeled outputs are independent" test_labeled
+  ]
+
+test_localList :: Assertion
+test_localList = runEff $ do
+  (r, xs) <- OLL.runOutput $ do
+    mapM_ OLL.output values
+    pure "done"
+  U.assertEqual "value" "done" r
+  U.assertEqual "list" values xs
+
+test_localArray :: Assertion
+test_localArray = runEff $ do
+  (r, arr) <- OLA.runOutput $ do
+    mapM_ OLA.output values
+    pure "done"
+  U.assertEqual "value" "done" r
+  U.assertEqual "array" values (F.toList arr)
+
+test_sharedList :: Assertion
+test_sharedList = runEff $ do
+  (r, xs) <- OSL.runOutput $ do
+    mapM_ OSL.output values
+    pure "done"
+  U.assertEqual "value" "done" r
+  U.assertEqual "list" values xs
+
+test_sharedArray :: Assertion
+test_sharedArray = runEff $ do
+  (r, arr) <- OSA.runOutput $ do
+    mapM_ OSA.output values
+    pure "done"
+  U.assertEqual "value" "done" r
+  U.assertEqual "array" values (F.toList arr)
+
+test_action :: Assertion
+test_action = runEff $ do
+  (_, acc) <- runState @[Int] [] . OA.runOutput @Int (\o -> modify (o :)) $ do
+    mapM_ OA.output values
+  U.assertEqual "values fed in order" (reverse values) acc
+
+test_dynamic :: Assertion
+test_dynamic = runEff $ do
+  (_, la) <- OD.runOutputLocalArray prog
+  U.assertEqual "local array" values (F.toList la)
+  (_, ll) <- OD.runOutputLocalList prog
+  U.assertEqual "local list" values ll
+  (_, sa) <- OD.runOutputSharedArray prog
+  U.assertEqual "shared array" values (F.toList sa)
+  (_, sl) <- OD.runOutputSharedList prog
+  U.assertEqual "shared list" values sl
+  (_, acc) <- runState @[Int] [] . OD.runOutputAction @Int (\o -> modify (o :)) $ prog
+  U.assertEqual "action" (reverse values) acc
+  where
+    prog :: (HasCallStack, OD.Output Int :> es) => Eff es ()
+    prog = mapM_ OD.output values
+
+test_labeled :: Assertion
+test_labeled = runEff $ do
+  ((_, bs), as) <- LO.runOutputLocalList @"a" @Int . LO.runOutputLocalList @"b" @Int $ do
+    LO.output @"a" @Int 1
+    LO.output @"b" @Int 10
+    LO.output @"a" @Int 2
+    LO.output @"b" @Int 20
+  U.assertEqual "label a" [1, 2] as
+  U.assertEqual "label b" [10, 20] bs
+
+-- | Emitting more values than the initial (zero) capacity exercises the array
+-- growth path in the array backends.
+values :: [Int]
+values = [1 .. 10]


### PR DESCRIPTION
Proof of concept.

- `Effectful.Input.Const` as a restricted version of `Reader` for ensuring that the input parameter doesn't change (static only, since with a dynamic you can change it with `interpose`).
- `Effectful.Output.Array` is the correct alternative to `Writer` when you just want to accumulate values.

And then it turned out that these are generalized by the `Coroutine` effect, so might as well also include it, it looks like there's no point providing a dynamic `Input` and `Output`.

Opinions welcome.
