### PR TITLE
Add withException, similar to safe-exceptions and unliftio. Closes #304

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -1,4 +1,5 @@
 # effectful-core-2.6.0.0 (????-??-??)
+* Add `withException` to `Effectful.Exception`, similar to safe-exceptions and unliftio.
 * **Breaking changes**:
   - Change the order of type parameters in `raise` for better usability.
   - `Effectful.Error.Static.ErrorWrapper` is no longer caught by `catchSync`.


### PR DESCRIPTION
I copied and edited the [code from unliftio](https://hackage.haskell.org/package/unliftio-0.2.25.0/docs/src/UnliftIO.Exception.html#withException). Since other functions from Effectful.Exception are used, the withRunInIO in the original code isn't needed, but I don't know if it would be better to use reallyUnsafeUnliftIO and call the Control.Exception functions directly. I'm not an expert on exceptions, so I don't know if it affects the safety.

For reference, [safe-exceptions has a slightly different implementation](https://hackage.haskell.org/package/safe-exceptions-0.1.7.4/docs/src/Control.Exception.Safe.html#withException) that uses generalBracket.