### PR TITLE
Add Effectful.ST and Effectful.ST.STRef

### DIFF
--- a/effectful/CHANGELOG.md
+++ b/effectful/CHANGELOG.md
@@ -3,6 +3,7 @@
   `Eff` for compatibility with existing code.
 * Re-export `writeTMVar` from `stm-2.5.1.0` in `Effectful.Concurrent.STM`.
 * Add `cancelMany` to `Effectful.Concurrent.Async`.
+* Add `Effectful.ST` and `Effectful.ST.STRef`
 
 # effectful-core-2.6.0.0 (2025-06-13)
 * Adjust `generalBracket` with `base >= 4.21` to make use of the new exception

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -106,6 +106,8 @@ library
                      Effectful.Prim.IORef
                      Effectful.Prim.IORef.Strict
                      Effectful.Process
+                     Effectful.ST
+                     Effectful.ST.STRef
                      Effectful.Temporary
                      Effectful.Timeout
 
@@ -171,6 +173,7 @@ test-suite test
                     PrimTests
                     ReaderTests
                     StateTests
+                    STTests
                     TimeoutTests
                     UnliftTests
                     Utils

--- a/effectful/src/Effectful/ST.hs
+++ b/effectful/src/Effectful/ST.hs
@@ -1,0 +1,28 @@
+module Effectful.ST (STE, runSTE, liftST) where
+
+import Control.Monad.ST (ST)
+import Control.Monad.ST.Unsafe (unsafeSTToIO)
+import Data.Kind (Type)
+import Data.Proxy (Proxy (..))
+
+import Effectful
+import Effectful.Dispatch.Static
+
+-- | An effect for embedding 'ST' computations
+data STE (s :: Type) :: Effect
+type role STE nominal phantom phantom
+
+type instance DispatchOf (STE s) = Static NoSideEffects
+data instance StaticRep (STE s) = STE
+
+-- | Run the 'STE' effect.
+-- Since effectful allows several 'STE' effects to be in scope at once,
+-- it can be ambiguous which one a usage of 'liftST' refers to.
+-- In these cases, the 'Proxy' parameter can be used to disambiguate.
+-- In particular, instead of @liftST $ newSTRef x@, you will have to write 
+-- @liftST \@s $ newSTRef x@.
+runSTE :: (forall s. Proxy s -> Eff (STE s : es) a) -> Eff es a
+runSTE eff = evalStaticRep STE (eff Proxy)
+
+liftST :: forall s a es. (STE s :> es) => ST s a -> Eff es a
+liftST st = unsafeEff_ (unsafeSTToIO st)

--- a/effectful/src/Effectful/ST/STRef.hs
+++ b/effectful/src/Effectful/ST/STRef.hs
@@ -1,0 +1,28 @@
+-- | Lifted "Data.STRef"
+module Effectful.ST.STRef (STRef, newSTRef, readSTRef, writeSTRef, modifySTRef, modifySTRef') where
+
+import Data.STRef (STRef)
+import Data.STRef qualified as STRef
+
+import Effectful
+import Effectful.ST
+
+-- Lifted 'STRef.newSTRef'
+newSTRef :: forall s a es. (STE s :> es) => a -> Eff es (STRef s a)
+newSTRef = liftST . STRef.newSTRef
+
+-- Lifted 'STRef.readSTRef'
+readSTRef :: forall s a es. (STE s :> es) => STRef s a -> Eff es a
+readSTRef = liftST . STRef.readSTRef
+
+-- Lifted 'STRef.writeSTRef'
+writeSTRef :: forall s a es. (STE s :> es) => STRef s a -> a -> Eff es ()
+writeSTRef ref = liftST . STRef.writeSTRef ref
+
+-- Lifted 'STRef.modifySTRef'
+modifySTRef :: forall s a es. (STE s :> es) => STRef s a -> (a -> a) -> Eff es ()
+modifySTRef ref = liftST . STRef.modifySTRef ref
+
+-- Lifted 'STRef.modifySTRef''
+modifySTRef' :: forall s a es. (STE s :> es) => STRef s a -> (a -> a) -> Eff es ()
+modifySTRef' ref = liftST . STRef.modifySTRef' ref

--- a/effectful/tests/STTests.hs
+++ b/effectful/tests/STTests.hs
@@ -1,0 +1,25 @@
+module STTests (stTests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Effectful
+import Effectful.ST
+import Effectful.ST.STRef
+import Utils qualified as U
+
+import Data.Foldable (for_)
+import Data.Proxy (Proxy (..))
+
+stTests :: TestTree
+stTests = testGroup "ST"
+    [ testCase "sumSTRef" test_sumSTRef
+    ]
+
+test_sumSTRef :: Assertion
+test_sumSTRef = runEff $ runSTE $ \(Proxy :: Proxy s) -> do
+    sumRef <- newSTRef @s @Int 0
+    for_ [0 .. 20] $ \i -> do
+        modifySTRef' sumRef (+ i)
+    result <- readSTRef sumRef
+    U.assertEqual "correct sum" result (sum [0 .. 20])


### PR DESCRIPTION
With this, effectful is able to mix `STE` with other effects, which makes it a very convenient way to avoid having to depend on `IOE` just to locally use mutable data structures.

The effect is tagged with an `s` region parameter and `runSTE` uses the same higher rank type trick as regular `runST` to prevent references from escaping.

I'm pretty sure that this is sound, however `ST` can be subtle so it would be nice to have a second opinion.
For some prior art: Koka uses [a similar `st` effect](https://koka-lang.github.io/koka/doc/std_core_types.html#type_space_st) that can be combined with arbitrary other effects.
References escaping through other effects (e.g. exceptions) shouldn't be an issue since that can only happen through an existential, at which point the reference cannot be accessed anymore anyway.

One thing I'm not entirely sure about is the type role on `STE`. The region parameter needs to be nominal for soundness, but making the others `phantom` seems a bit dangerous? This is also what is inferred for other effects like `Process` though.