### PR TITLE
Benchmark mtl code run via transformers and effectful

### DIFF
--- a/effectful/bench/Countdown.hs
+++ b/effectful/bench/Countdown.hs
@@ -95,17 +95,29 @@ programMtl = do
       programMtl
 {-# NOINLINE programMtl #-}
 
-countdownMtl :: Integer -> (Integer, Integer)
-countdownMtl n = flip M.runState n $ programMtl
+countdownMtlTransformers :: Integer -> (Integer, Integer)
+countdownMtlTransformers n = flip M.runState n $ programMtl
 
-countdownMtlDeep :: Integer -> (Integer, Integer)
-countdownMtlDeep n = runIdentity
+countdownMtlTransformersDeep :: Integer -> (Integer, Integer)
+countdownMtlTransformersDeep n = runIdentity
   . runR . runR . runR . runR . runR
   . flip M.runStateT n
   . runR . runR . runR . runR . runR
   $ programMtl
   where
     runR = flip M.runReaderT ()
+
+countdownMtlEffectful :: Integer -> (Integer, Integer)
+countdownMtlEffectful n = E.runPureEff . ED.runStateLocal n $ programMtl
+
+countdownMtlEffectfulDeep :: Integer -> (Integer, Integer)
+countdownMtlEffectfulDeep n = E.runPureEff
+  . runR . runR . runR . runR . runR
+  . ED.runStateLocal n
+  . runR . runR . runR . runR . runR
+  $ programMtl
+  where
+    runR = E.runReader ()
 
 #endif
 

--- a/effectful/bench/Main.hs
+++ b/effectful/bench/Main.hs
@@ -103,9 +103,13 @@ countdown n = bgroup (show n)
     ]
 #endif
 #ifdef VERSION_mtl
-  , bgroup "mtl"
-    [ bench "shallow" $ nf countdownMtl n
-    , bench "deep"    $ nf countdownMtlDeep n
+  , bgroup "mtl (transformers)"
+    [ bench "shallow" $ nf countdownMtlTransformers n
+    , bench "deep"    $ nf countdownMtlTransformersDeep n
+    ]
+  , bgroup "mtl (effectful)"
+    [ bench "shallow" $ nf countdownMtlEffectful n
+    , bench "deep"    $ nf countdownMtlEffectfulDeep n
     ]
 #endif
 #ifdef VERSION_fused_effects
@@ -148,9 +152,13 @@ filesize n = bgroup (show n)
     ]
 #endif
 #ifdef VERSION_mtl
-  , bgroup "mtl"
-    [ bench "shallow" $ nfAppIO mtl_calculateFileSizes (take n files)
-    , bench "deep"    $ nfAppIO mtl_calculateFileSizesDeep (take n files)
+  , bgroup "mtl (transformers)"
+    [ bench "shallow" $ nfAppIO mtl_calculateFileSizesTransformers (take n files)
+    , bench "deep"    $ nfAppIO mtl_calculateFileSizesTransformersDeep (take n files)
+    ]
+  , bgroup "mtl (effectful)"
+    [ bench "shallow" $ nfAppIO mtl_calculateFileSizesEffectful (take n files)
+    , bench "deep"    $ nfAppIO mtl_calculateFileSizesEffectfulDeep (take n files)
     ]
 #endif
 #ifdef VERSION_fused_effects


### PR DESCRIPTION
Turns out that running unspecialized code written with mtl style effects in mind via effectful's `Eff` is always faster than running via a transformer stack. Crazy.

`countdown.1000`:

```
mtl (transformers)
  shallow:        OK
    51.1 μs ± 2.9 μs, 477 KB allocated,  92 B  copied, 6.0 MB peak memory
  deep:           OK
    409  μs ±  33 μs, 3.0 MB allocated, 870 B  copied, 6.0 MB peak memory
mtl (effectful)
  shallow:        OK
    36.4 μs ± 2.9 μs, 260 KB allocated,  71 B  copied, 6.0 MB peak memory
  deep:           OK
    36.9 μs ± 2.9 μs, 267 KB allocated, 179 B  copied, 6.0 MB peak memory
```

`filesize.1000`:
```
mtl (transformers)
  shallow: OK
    973  μs ±  87 μs, 7.2 MB allocated, 349 KB copied, 7.0 MB peak memory
  deep:    OK
    2.20 ms ± 175 μs,  15 MB allocated, 854 KB copied, 8.0 MB peak memory
mtl (effectful)
  shallow: OK
    818  μs ±  44 μs, 6.5 MB allocated, 196 KB copied, 8.0 MB peak memory
  deep:    OK
    883  μs ±  77 μs, 6.6 MB allocated, 210 KB copied, 8.0 MB peak memory
```