### PR TITLE
Rename Effectful.Internal.MTL to Effectful.Internal.Effect.Dynamic

### DIFF
--- a/effectful-core/CHANGELOG.md
+++ b/effectful-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Drop support for GHC < 9.6.
 * Add definitions of `rethrowM` to `MonadThrow` and `catchNoPropagate` to
   `MonadCatch` instances for `Eff` when appropriate (`exceptions` >= 0.10.11).
+* Rename `Effectful.Internal.MTL` module to `Effectful.Internal.Effect.Dynamic`.
 
 # effectful-core-2.6.1.0 (2025-08-30)
 * Add `MonadError`, `MonadReader`, `MonadState` and `MonadWriter` instances for

--- a/effectful-core/effectful-core.cabal
+++ b/effectful-core/effectful-core.cabal
@@ -91,8 +91,8 @@ library
                      Effectful.Exception
                      Effectful.Fail
                      Effectful.Internal.Effect
+                     Effectful.Internal.Effect.Dynamic
                      Effectful.Internal.Env
-                     Effectful.Internal.MTL
                      Effectful.Internal.Monad
                      Effectful.Internal.Unlift
                      Effectful.Internal.Utils

--- a/effectful-core/src/Effectful.hs
+++ b/effectful-core/src/Effectful.hs
@@ -63,8 +63,8 @@ import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
 
 import Effectful.Internal.Effect
+import Effectful.Internal.Effect.Dynamic ()
 import Effectful.Internal.Env
-import Effectful.Internal.MTL ()
 import Effectful.Internal.Monad
 
 -- $intro

--- a/effectful-core/src/Effectful/Error/Dynamic.hs
+++ b/effectful-core/src/Effectful/Error/Dynamic.hs
@@ -34,7 +34,7 @@ import GHC.Stack (withFrozenCallStack)
 import Effectful
 import Effectful.Dispatch.Dynamic
 import Effectful.Error.Static qualified as E
-import Effectful.Internal.MTL (Error(..))
+import Effectful.Internal.Effect.Dynamic (Error(..))
 
 -- | Handle errors of type @e@ (via "Effectful.Error.Static").
 runError

--- a/effectful-core/src/Effectful/Internal/Effect/Dynamic.hs
+++ b/effectful-core/src/Effectful/Internal/Effect/Dynamic.hs
@@ -3,7 +3,7 @@
 --
 -- This module is intended for internal use only, and may change without warning
 -- in subsequent releases.
-module Effectful.Internal.MTL where
+module Effectful.Internal.Effect.Dynamic where
 
 import Control.Monad.Except qualified as MTL
 import Control.Monad.Reader qualified as MTL

--- a/effectful-core/src/Effectful/Reader/Dynamic.hs
+++ b/effectful-core/src/Effectful/Reader/Dynamic.hs
@@ -20,7 +20,7 @@ module Effectful.Reader.Dynamic
 
 import Effectful
 import Effectful.Dispatch.Dynamic
-import Effectful.Internal.MTL (Reader(..))
+import Effectful.Internal.Effect.Dynamic (Reader(..))
 
 -- | Run the 'Reader' effect with the given initial environment.
 runReader

--- a/effectful-core/src/Effectful/State/Dynamic.hs
+++ b/effectful-core/src/Effectful/State/Dynamic.hs
@@ -32,7 +32,7 @@ module Effectful.State.Dynamic
 
 import Effectful
 import Effectful.Dispatch.Dynamic
-import Effectful.Internal.MTL (State(..))
+import Effectful.Internal.Effect.Dynamic (State(..))
 import Effectful.State.Static.Local qualified as L
 import Effectful.State.Static.Shared qualified as S
 

--- a/effectful-core/src/Effectful/Writer/Dynamic.hs
+++ b/effectful-core/src/Effectful/Writer/Dynamic.hs
@@ -27,7 +27,7 @@ module Effectful.Writer.Dynamic
 
 import Effectful
 import Effectful.Dispatch.Dynamic
-import Effectful.Internal.MTL (Writer(..))
+import Effectful.Internal.Effect.Dynamic (Writer(..))
 import Effectful.Writer.Static.Local qualified as L
 import Effectful.Writer.Static.Shared qualified as S
 


### PR DESCRIPTION
For no confusing 'MTL' shown if GHC shows these effects fully qualified.